### PR TITLE
Fix showing absolute path in source control tree view

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -120,6 +120,7 @@ class RepositorySourceControlManager {
     this.sourceControl = vscode.scm.createSourceControl(
       "jj",
       path.basename(repositoryRoot),
+      vscode.Uri.file(repositoryRoot),
     );
     this.subscriptions.push(this.sourceControl);
 


### PR DESCRIPTION
Currently the tree view in the source control section shows the absolute path of the repository:

![image](https://github.com/user-attachments/assets/55bc543d-b055-4b65-8715-bfccd385bd99)

This PR fixes that by giving the repository root to the vscode, so it can strip it from the paths. But then I found out that it only works for the working copy and not parents, due parents using `jj` scheme, and vscode doesn't like that. I removed the `jj` scheme, which is probably wrong, but I wasn't sure what to do so I just submitted the patch to get feedback.