### PR TITLE
Add graph view with custom revset

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,16 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "jj.openExpandedGraphWebview",
+        "title": "Open the expanded source control graph view",
+        "icon": "$(history)"
+      },
+      {
+        "command": "jj.fileHistory",
+        "title": "View file history",
+        "icon": "$(history)"
+      },
+      {
         "command": "jj.mergeGraphWebview",
         "title": "Create merge change with selected as parents",
         "icon": "$(git-merge)"
@@ -136,6 +146,12 @@
       }
     ],
     "menus": {
+      "explorer/context": [
+        {
+          "command": "jj.fileHistory",
+          "when": "resourceScheme == file"
+        }
+      ],
       "view/title": [
         {
           "command": "jj.refreshOperationLog",
@@ -149,6 +165,11 @@
         },
         {
           "command": "jj.refreshGraphWebview",
+          "when": "view == jjGraphWebview",
+          "group": "navigation"
+        },
+        {
+          "command": "jj.openExpandedGraphWebview",
           "when": "view == jjGraphWebview",
           "group": "navigation"
         },

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -4,9 +4,16 @@ import type { JJRepository } from "./repository";
 import path from "path";
 
 type Message = {
-  command: string;
-  changeId: string;
+  command: "selectChange";
   selectedNodes: string[];
+} | {
+  command: "updateRevset";
+  revset: string;
+} | {
+  command: "editChange";
+  changeId: string;
+} | {
+  command: "webviewReady";
 };
 
 export type RefreshArgs = {
@@ -43,6 +50,9 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
   }[] = [];
 
   public panel?: vscode.WebviewView;
+  public webview?: vscode.Webview;
+  public revset: string;
+  public mode: "expanded" | "compact";
   public repository: JJRepository;
   public logData: ChangeNode[] = [];
   public selectedNodes: Set<string> = new Set();
@@ -51,17 +61,24 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
     private readonly extensionUri: vscode.Uri,
     repo: JJRepository,
     private readonly context: vscode.ExtensionContext,
+    initialRevset: string = "::",
+    mode: "expanded" | "compact" = 'compact',
+    register: boolean = true,
   ) {
     this.repository = repo;
+    this.mode = mode;
+    this.revset = initialRevset;
 
-    // Register the webview provider
-    context.subscriptions.push(
-      vscode.window.registerWebviewViewProvider("jjGraphWebview", this, {
-        webviewOptions: {
-          retainContextWhenHidden: true,
-        },
-      }),
-    );
+    if (register) {
+      // Register the webview provider
+      context.subscriptions.push(
+        vscode.window.registerWebviewViewProvider("jjGraphWebview", this, {
+          webviewOptions: {
+            retainContextWhenHidden: true,
+          },
+        }),
+      );
+    }
   }
 
   public async resolveWebviewView(
@@ -69,16 +86,23 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
   ): Promise<void> {
     this.panel = webviewView;
     this.panel.title = `Source Control Graph (${path.basename(this.repository.repositoryRoot)})`;
+    await this.resolveWebview(webviewView.webview);
+  }
 
-    webviewView.webview.options = {
+  public async resolveWebview(
+    webview: vscode.Webview,
+  ): Promise<void> {
+    this.webview = webview;    
+
+    webview.options = {
       enableScripts: true,
       localResourceRoots: [this.extensionUri],
     };
 
-    webviewView.webview.html = this.getWebviewContent(webviewView.webview);
+    webview.html = this.getWebviewContent(webview);
 
     await new Promise<void>((resolve) => {
-      const messageListener = webviewView.webview.onDidReceiveMessage(
+      const messageListener = webview.onDidReceiveMessage(
         (message: Message) => {
           if (message.command === "webviewReady") {
             messageListener.dispose();
@@ -88,7 +112,7 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
       );
     });
 
-    webviewView.webview.onDidReceiveMessage(async (message: Message) => {
+    webview.onDidReceiveMessage(async (message: Message) => {
       switch (message.command) {
         case "editChange":
           try {
@@ -102,6 +126,10 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
               `Failed to switch to change: ${error as string}`,
             );
           }
+          break;
+        case "updateRevset":
+          this.revset = message.revset;
+          await this.refresh(true, true);
           break;
         case "selectChange":
           this.selectedNodes = new Set(message.selectedNodes);
@@ -125,12 +153,12 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
   }
 
   public async refresh(preserveScroll: boolean = false, force: boolean = false) {
-    if (!this.panel) {
+    if (!this.webview) {
       return;
     }
     const currChanges = this.logData;
 
-    let changes = parseJJLog(await this.repository.log());
+    let changes = parseJJLog(await this.repository.log(this.revset));
     changes = await this.getChangeNodesWithParents(changes);
     this.logData = changes;
 
@@ -145,7 +173,7 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
       !this.areChangeNodesEqual(currChanges, changes)
     ) {
       this.selectedNodes.clear();
-      this.panel.webview.postMessage({
+      this.webview.postMessage({
         command: "updateGraph",
         changes: changes,
         workingCopyId,
@@ -185,6 +213,8 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
     // Replace placeholders in the HTML
     html = html.replace("${cssUri}", cssUri.toString());
     html = html.replace("${codiconUri}", codiconUri.toString());
+    html = html.replace("${mode}", this.mode);
+    html = html.replace("${initialRevset}", this.revset);
 
     return html;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   let operationLogManager: OperationLogManager | undefined;
   let graphWebview: JJGraphWebview;
+  let tempGraphWebviews: JJGraphWebview[] = [];
 
   vscode.workspace.onDidChangeWorkspaceFolders(
     async () => {
@@ -569,6 +570,54 @@ export async function activate(context: vscode.ExtensionContext) {
       }),
     );
 
+    const openExpandedGraphWebview = async (revset: string) => {
+      const myGraphWebview = new JJGraphWebview(
+        context.extensionUri,
+        selectedRepo,
+        context,
+        revset,
+        'expanded',
+        false,
+      );
+
+      tempGraphWebviews.push(myGraphWebview);
+
+      const panel = vscode.window.createWebviewPanel(
+        'JJExpandedGraphWebview',
+        'JJ Graph',
+        vscode.ViewColumn.One,
+        { enableScripts: true }
+      );
+
+      panel.onDidDispose(() => {
+        tempGraphWebviews = tempGraphWebviews.filter((tempGraphWebview) => tempGraphWebview !== myGraphWebview);
+      });
+
+      await myGraphWebview.resolveWebview(panel.webview);
+    };
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand('jj.fileHistory', async (uri?: vscode.Uri) => {
+        if (!uri) {
+          await openExpandedGraphWebview("::");
+          return;
+        }
+        const root = workspaceSCM.getRepositoryFromUri(uri)?.repositoryRoot;
+        if (!root) {
+          await openExpandedGraphWebview(`files(root:"${uri.path}")`);
+          return;
+        }
+        const path = uri.path.substring(root.length + 1);
+        await openExpandedGraphWebview(`files(root:"${path}")`);
+      }),
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand("jj.openExpandedGraphWebview", async () => {
+        await openExpandedGraphWebview("::");
+      }),
+    );
+
     context.subscriptions.push(
       vscode.commands.registerCommand("jj.mergeGraphWebview", async () => {
         const selectedNodes = Array.from(graphWebview.selectedNodes);
@@ -717,6 +766,9 @@ export async function activate(context: vscode.ExtensionContext) {
       graphWebview.setSelectedRepository(selectedRepo);
 
       await graphWebview.refresh(finalArgs.preserveScroll);
+      for (const tempGraphWebview of tempGraphWebviews) {
+        await tempGraphWebview.refresh(finalArgs.preserveScroll, true);
+      }
 
       if (operationLogManager) {
         void operationLogManager.setSelectedRepo(selectedRepo);

--- a/src/webview/graph.css
+++ b/src/webview/graph.css
@@ -11,6 +11,10 @@ body {
     padding-left: 8px;
 }
 
+#revsetInput {
+    width: 50%;
+}
+
 #connections {
     position: absolute;
     top: 0;

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -7,6 +7,9 @@
 </head>
 
 <body>
+    <div id="toolbar" hidden>
+        Selected revset: <input type="text" id="revsetInput">
+    </div>
     <div id="graph">
         <svg id="connections">
             <defs id="svg-defs"></defs>
@@ -19,6 +22,21 @@
         const vscode = acquireVsCodeApi();
         let selectedNodes = new Set();
         let currentWorkingCopyId;
+
+        const mode = '${mode}';
+        if (mode === 'expanded') {
+            document.getElementById('toolbar').removeAttribute('hidden');
+        }
+
+        const revsetInput = document.getElementById('revsetInput');
+
+        revsetInput.value = '${initialRevset}';
+        revsetInput.oninput = (e) => {
+            vscode.postMessage({
+                command: 'updateRevset',
+                revset: e.target.value,
+            });
+        };
 
         window.addEventListener('message', event => {
             const message = event.data;


### PR DESCRIPTION
Ability of querying commits is a nice feature of jj, and not being a fan of terminal graphs, I decided to bring it to jjk. This PR adds another graph view which accepts custom revset (can accept more configuration in future) and appears in a bigger screen, and also add a `File History` menu item on top of that:

![image](https://github.com/user-attachments/assets/9f010fa9-ace1-4027-9a03-3b08085c03da)
