### PR TITLE
Show ignored files in gray

### DIFF
--- a/src/uri.ts
+++ b/src/uri.ts
@@ -39,3 +39,14 @@ export function getRev(uri: Uri) {
   }
   return parsed.rev;
 }
+
+export function getRevOpt(uri: Uri) {
+  if (uri.query === "") {
+    return;
+  }
+  const parsed = JSON.parse(uri.query) as unknown;
+  if (!isJJUriParams(parsed)) {
+    return;
+  }
+  return parsed.rev;
+}


### PR DESCRIPTION
This PR fixes missing decorations in file explorer, which is probably regressed in https://github.com/keanemind/jjk/commit/d08911f517cddc57e15317a7f634297c4c596d26 , and adds support for graying out ignored files. ~I didn't find out how to ask tracked/ignored files list from jj, so current implementation is git based and not absolutely correct (e.g. it doesn't handle explicitly tracked files), and it is not auto updated, but I think it is still better than nothing.~ I found that there is a `jj file list` that lists the tracked files, and I used that.