### PR TITLE
Use jj log instead of show

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -441,7 +441,7 @@ export class JJRepository {
       const template =
         templateFields.join(` ++ "${separator}" ++ `) + ` ++ "${separator}"`;
 
-      const childProcess = spawnJJ(["show", "-T", template, rev], {
+      const childProcess = spawnJJ(["log", "-T", template, "--no-graph", "-r", rev], {
         timeout: 5000,
         cwd: this.repositoryRoot,
       });


### PR DESCRIPTION
When operating on a single change, jj show is equivalent to jj log except it always appends the diff to the end of the output.

jj show was generating and appending the full diff after the template fields, and since I had a custom diff tool configured that ran fairly slowly, it was causing the command to timeout.

Since the extension isn't even reading the diff, it's better to switch to jj log to avoid generating the diff.

## Notes

To show some sample equivalent commands:

These two commands are equivalent:
- `jj log --no-graph -T 'change_id ++ " ==> " ++ diff.summary()' -r @`
- `jj show --summary -T 'change_id ++ " => "' @`

These two commands are also equivalent:
- `jj log --no-graph -T 'change_id ++ " ==> " ++ diff.git()' -r @`
- `jj show --git -T 'change_id ++ " => "' @`
