### PR TITLE
.gitignore: add out/ and .vscode-test/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .cache
 node_modules/
 dist/
+out/
+.vscode-test/
 *.vsix
 src/**/*.js
 src/**/*.js.map


### PR DESCRIPTION
These dirs appeared when I ran `npm test`.

I also wonder whether the `src/**/*.js` .gitignore is necessary, since all the js files seem to go into `out/`, at least in my experience.