### PR TITLE
Defer registration of file decoration provider until file statues are available

### DIFF
--- a/src/decorationProvider.ts
+++ b/src/decorationProvider.ts
@@ -23,14 +23,31 @@ const colorOfType = (type: FileStatusType) => {
 };
 
 export class JJDecorationProvider implements FileDecorationProvider {
-  private isReady = false;
-  private decorations = new Map<string, FileDecoration>();
-  private trackedFiles = new Set<string>();
-  private urisRequestedBeforeReady = new Set<string>();
-
   private readonly _onDidChangeDecorations = new EventEmitter<Uri[]>();
   readonly onDidChangeFileDecorations: Event<Uri[]> =
     this._onDidChangeDecorations.event;
+  private decorations: Map<string, FileDecoration>;
+  private trackedFiles: Set<string>;
+
+  constructor(
+    fileStatusesByChange: Map<string, FileStatus[]>,
+    trackedFiles: Set<string>,
+  ) {
+    const nextDecorations = new Map<string, FileDecoration>();
+    for (const [changeId, fileStatuses] of fileStatusesByChange) {
+      for (const fileStatus of fileStatuses) {
+        const key = getKey(Uri.file(fileStatus.path).fsPath, changeId);
+        nextDecorations.set(key, {
+          badge: fileStatus.type,
+          tooltip: fileStatus.file,
+          color: colorOfType(fileStatus.type),
+        });
+      }
+    }
+
+    this.decorations = nextDecorations;
+    this.trackedFiles = trackedFiles;
+  }
 
   onRefresh(
     fileStatusesByChange: Map<string, FileStatus[]>,
@@ -49,70 +66,53 @@ export class JJDecorationProvider implements FileDecorationProvider {
     }
 
     const changedDecorationKeys = new Set<string>();
-    if (this.isReady) {
-      for (const [key, fileDecoration] of nextDecorations) {
-        if (
-          !this.decorations.has(key) ||
-          this.decorations.get(key)!.badge !== fileDecoration.badge
-        ) {
-          changedDecorationKeys.add(key);
-        }
+    for (const [key, fileDecoration] of nextDecorations) {
+      if (
+        !this.decorations.has(key) ||
+        this.decorations.get(key)!.badge !== fileDecoration.badge
+      ) {
+        changedDecorationKeys.add(key);
       }
-      for (const key of this.decorations.keys()) {
-        if (!nextDecorations.has(key)) {
-          changedDecorationKeys.add(key);
-        }
+    }
+    for (const key of this.decorations.keys()) {
+      if (!nextDecorations.has(key)) {
+        changedDecorationKeys.add(key);
       }
     }
 
-    const changedTrackedFiles = new Set<string>(
-      this.isReady
-        ? [
-            ...[...trackedFiles.values()].filter(
-              (file) => !this.trackedFiles.has(file),
-            ),
-            ...[...this.trackedFiles.values()].filter(
-              (file) => !trackedFiles.has(file),
-            ),
-          ]
-        : [],
-    );
+    const changedTrackedFiles = new Set<string>([
+      ...[...trackedFiles.values()].filter(
+        (file) => !this.trackedFiles.has(file),
+      ),
+      ...[...this.trackedFiles.values()].filter(
+        (file) => !trackedFiles.has(file),
+      ),
+    ]);
 
     this.decorations = nextDecorations;
     this.trackedFiles = trackedFiles;
 
-    const changedUris = this.isReady
-      ? [
-          ...[...changedDecorationKeys.keys()].map((key) => {
-            const [fsPath, rev] = key.split(":");
-            return withRev(Uri.file(fsPath), rev);
-          }),
-          ...[...changedDecorationKeys.keys()]
-            .map((key) => {
-              const [fsPath, rev] = key.split(":");
-              if (rev === "@") {
-                return Uri.file(fsPath);
-              }
-            })
-            .filter((x): x is Uri => !!x),
-          ...[...changedTrackedFiles.values()].map((file) => Uri.file(file)),
-        ]
-      : [...this.urisRequestedBeforeReady.values()].map((file) =>
-          Uri.file(file),
-        );
+    const changedUris = [
+      ...[...changedDecorationKeys.keys()].map((key) => {
+        const [fsPath, rev] = key.split(":");
+        return withRev(Uri.file(fsPath), rev);
+      }),
+      ...[...changedDecorationKeys.keys()]
+        .filter((key) => {
+          const [_, rev] = key.split(":");
+          return rev === "@";
+        })
+        .map((key) => {
+          const [fsPath] = key.split(":");
+          return Uri.file(fsPath);
+        }),
+      ...[...changedTrackedFiles.values()].map((file) => Uri.file(file)),
+    ];
 
-    this.urisRequestedBeforeReady.clear();
-
-    this.isReady = true;
     this._onDidChangeDecorations.fire(changedUris);
   }
 
   provideFileDecoration(uri: Uri): FileDecoration | undefined {
-    if (!this.isReady) {
-      this.urisRequestedBeforeReady.add(uri.fsPath);
-      return undefined;
-    }
-
     const rev = getRevOpt(uri) ?? "@";
     const key = getKey(uri.fsPath, rev);
     if (rev === "@" && !this.decorations.has(key)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+import type { JJDecorationProvider } from "./decorationProvider";
+
+export type FileDecorationProviderGetter = (
+  ...params: ConstructorParameters<typeof JJDecorationProvider>
+) => JJDecorationProvider;


### PR DESCRIPTION
This lets us get rid of the `decorationsProvidedSinceLastRefresh` hack. As soon as we register a file decoration provider, it will get its `provideFileDecoration` method called a bunch of times for various files. This means we don't want to register our file system provider until we've finished refreshing at least once, so that we actually know how files should be decorated.