### PR TITLE
Update blame decoration when text is edited to keep it at the end of the line

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -260,6 +260,17 @@ export async function activate(context: vscode.ExtensionContext) {
         await setDecorations(e.textEditor, activeLines);
       }),
     );
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeTextDocument(async (e) => {
+        const editor = vscode.window.activeTextEditor;
+        if (
+          editor &&
+          editor.document.uri.toString() === e.document.uri.toString()
+        ) {
+          await setDecorations(editor, activeLines);
+        }
+      }),
+    );
     if (vscode.window.activeTextEditor) {
       void handleDidChangeActiveTextEditor(vscode.window.activeTextEditor);
     }


### PR DESCRIPTION
Fixes https://github.com/keanemind/jjk/issues/9