### PR TITLE
Remove command that doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,11 +156,6 @@
         "title": "​",
         "category": "Jujutsu",
         "enablement": "false"
-      },
-      {
-        "command": "jj.squashSelectedRanges",
-        "title": "Squash selected changes...",
-        "category": "Jujutsu"
       }
     ],
     "menus": {


### PR DESCRIPTION
Think this was accidentally introduced by a messed up rebase in #40 