### PR TITLE
Capture more logs

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import winston from "winston";
 import { config } from "./vendor/winston-transport-vscode/logOutputChannelTransport";
 
 export const logger = winston.createLogger({
-  level: "info",
+  level: "trace",
   transports: [
     new winston.transports.Console({
       format: winston.format.combine(

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,9 +19,6 @@ import winston from "winston";
 import { initConfigArgs } from "./repository";
 
 export async function activate(context: vscode.ExtensionContext) {
-  await initJJVersion();
-  await initConfigArgs(context.extensionUri);
-
   const outputChannel = vscode.window.createOutputChannel("Jujutsu Kaizen", {
     log: true,
   });
@@ -38,6 +35,9 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   logger.info("Extension activated");
+
+  await initJJVersion();
+  await initConfigArgs(context.extensionUri);
 
   const decorationProvider = new JJDecorationProvider((decorationProvider) => {
     context.subscriptions.push(


### PR DESCRIPTION
We're currently missing the logs from the call to jj version because it happens before log initialization, so I moved that down. We also should capture all log levels; users can filter the output channel by log level for display.