### PR TITLE
add .jj to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out/
 *.vsix
 src/**/*.js
 src/**/*.js.map
+.jj


### PR DESCRIPTION
This tells tooling that's not jj aware but that does respect `.gitignore` to avoid looking into the `.jj` folder