### PR TITLE
Fix unrecoverable error loop when race condition is encountered

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -257,8 +257,11 @@ class RepositorySourceControlManager {
   async refresh(status: RepositoryStatus) {
     if (!this.refreshPromise) {
       this.refreshPromise = this.refreshUnsafe(status);
-      await this.refreshPromise;
-      this.refreshPromise = undefined;
+      try {
+        await this.refreshPromise;
+      } finally {
+        this.refreshPromise = undefined;
+      }
     } else {
       await this.refreshPromise;
     }


### PR DESCRIPTION
The race condition is in `refreshUnsafe`, where it calls `jj status` and then calls `jj log -r` on each parent change that it saw in status. If a parent change no longer exists (because of a squash or other operation that happened in between) by the time the `jj log -r` call is made, the `jj log -r` call fails. This is normal and ok because we'll just try again at the next refresh attempt. However, the root problem was that the way I set up the promise handling, once the promise was rejected, it would stay rejected forever.