### PR TITLE
Fix edge cases with parsing `jj status` output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.6.2",
       "dependencies": {
         "@vscode/codicons": "^0.0.36",
+        "ansi-regex": "^6.1.0",
         "cross-spawn": "^7.0.6",
         "logform": "^2.7.0",
         "triple-beam": "^1.4.1",
@@ -1125,7 +1126,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -424,6 +424,7 @@
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.36",
+    "ansi-regex": "^6.1.0",
     "cross-spawn": "^7.0.6",
     "logform": "^2.7.0",
     "triple-beam": "^1.4.1",

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1003,7 +1003,7 @@ export type FileStatus = {
 export interface Change {
   changeId: string;
   commitId: string;
-  branch?: string;
+  bookmarks?: string[];
   description: string;
   isEmpty: boolean;
   isConflict: boolean;
@@ -1054,7 +1054,7 @@ async function parseJJStatus(
 
   const changeRegex = /^(A|M|D|R) (.+)$/;
   const commitRegex =
-    /^(Working copy|Parent commit)\s*(\(@-?\))?\s*:\s+(\S+)\s+(\S+)(?:\s+(\S+)\s+\|)?(?:\s+(.*))?$/;
+    /^(Working copy|Parent commit)\s*(\(@-?\))?\s*:\s+(\S+)\s+(\S+)(?:\s+(.+?)\s+\|)?(?:\s+(.*))?$/;
   const renameRegex = /^\{(.+) => (.+)\}$/;
 
   for (const line of lines) {
@@ -1101,7 +1101,7 @@ async function parseJJStatus(
         _at,
         changeId,
         commitId,
-        branch,
+        bookmarks,
         descriptionSection,
       ] = commitMatch as unknown as [string, ...(string | undefined)[]];
 
@@ -1120,7 +1120,9 @@ async function parseJJStatus(
       const commitDetails: Change = {
         changeId: await stripAnsiCodes(changeId),
         commitId: await stripAnsiCodes(commitId),
-        branch: branch ? await stripAnsiCodes(branch) : undefined,
+        bookmarks: bookmarks
+          ? (await stripAnsiCodes(bookmarks)).split(/\s+/)
+          : undefined,
         description: cleanedDescription,
         isEmpty: false,
         isConflict: false,


### PR DESCRIPTION
Previously we were including `(empty)` and `(conflict)` in the parsed description, leading to us presenting that as the description in things like the source control view and the description input that comes up when squashing. The way we distinguish the (empty) and (conflict) from those strings being in the change's description itself is using the ANSI sequences now, so we have to pass `--color=always` to `jj status`. 

Also, when multiple bookmarks were on the same change, it would break the regex and cause the parsed description to include the bookmarks, pipe character, and change description.