### PR TITLE
add language/grammar for .jjdescription

### DIFF
--- a/languages/jj-commit.language-configuration.json
+++ b/languages/jj-commit.language-configuration.json
@@ -1,0 +1,19 @@
+{
+	"comments": {
+		"lineComment": "JJ:",
+		"blockComment": [ "JJ:", " " ]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "`", "close": "`", "notIn": ["string", "comment"] },
+	]
+}

--- a/package.json
+++ b/package.json
@@ -405,6 +405,26 @@
           "highContrastLight": "editorCodeLens.foreground"
         }
       }
+    ],
+    "languages": [
+      {
+        "id": "jj-commit",
+        "aliases": [
+          "JJ Commit Message",
+          "jj-commit"
+        ],
+        "extensions": [
+          ".jjdescription"
+        ],
+        "configuration": "./languages/jj-commit.language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "jj-commit",
+        "scopeName": "text.jj-commit",
+        "path": "./syntaxes/jj-commit.tmLanguage.json"
+      }
     ]
   },
   "scripts": {

--- a/syntaxes/jj-commit.tmLanguage.json
+++ b/syntaxes/jj-commit.tmLanguage.json
@@ -1,0 +1,60 @@
+{
+    "name": "JJ Commit Message",
+    "scopeName": "text.jj-commit",
+    "patterns": [
+        {
+            "comment": "User supplied message",
+            "name": "meta.scope.message.jj-commit",
+            "begin": "^(?!JJ:)",
+            "end": "^(?=JJ:)",
+            "patterns": [
+                {
+                    "comment": "Mark > 50 lines as deprecated, > 72 as illegal",
+                    "name": "meta.scope.subject.jj-commit",
+                    "match": "\\G.{0,50}(.{0,22}(.*))$",
+                    "captures": {
+                        "1": {
+                            "name": "invalid.deprecated.line-too-long.jj-commit"
+                        },
+                        "2": {
+                            "name": "invalid.illegal.line-too-long.jj-commit"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "comment": "JJ supplied metadata in a number of lines starting with JJ:",
+            "name": "meta.scope.metadata.jj-commit",
+            "begin": "^(?=JJ:)",
+            "contentName": "comment.line.indicator.jj-commit",
+            "end": "^(?!JJ:)",
+            "patterns": [
+                {
+                    "match": "^JJ:\\s+((M|R) .*)$",
+                    "captures": {
+                        "1": {
+                            "name": "markup.changed.jj-commit"
+                        }
+                    }
+                },
+                {
+                    "match": "^JJ:\\s+(A .*)$",
+                    "captures": {
+                        "1": {
+                            "name": "markup.inserted.jj-commit"
+                        }
+                    }
+                },
+                {
+                    "match": "^JJ:\\s+(D .*)$",
+                    "captures": {
+                        "1": {
+                            "name": "markup.deleted.jj-commit"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds a language and grammar for `.jjdescription` files which allows for proper syntax highlighting of the `JJ:` comments, as well as the added/modified/deleted files. 

Adapted from VSCode's [git-base](https://github.com/microsoft/vscode/tree/296e736cd51c18cf5899662566cea384aa0550e0/extensions/git-base) extension for `git-commit`/`COMMIT_EDITMSG`

Screenshot of this commits description
![image](https://github.com/user-attachments/assets/b447220b-f75b-48bc-bf8a-7b2bf8f480b2)
