### PR TITLE
Add `diffOriginalRev` field to JJUriParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@vscode/codicons": "^0.0.36",
         "ansi-regex": "^6.1.0",
+        "arktype": "^2.1.19",
         "cross-spawn": "^7.0.6",
         "logform": "^2.7.0",
         "triple-beam": "^1.4.1",
@@ -36,6 +37,19 @@
       "engines": {
         "vscode": "^1.96.0"
       }
+    },
+    "node_modules/@ark/schema": {
+      "version": "0.45.9",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.45.9.tgz",
+      "integrity": "sha512-rG0v/JI0sibn/0wERAHTYVLCtEqoMP2IIlxnb+S5DrEjCI5wpubbZSWMDW50tZ8tV6FANu6zzHDeeKbp6lsZdg==",
+      "dependencies": {
+        "@ark/util": "0.45.9"
+      }
+    },
+    "node_modules/@ark/util": {
+      "version": "0.45.9",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.45.9.tgz",
+      "integrity": "sha512-0WYNAb8aRGp7dNt6xIvIrRzL7V1XL3u3PK2vcklhtTrdaP235DjC9qJhzidrxtWr68mA5ySSjUrgrXk622bKkw=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -1166,6 +1180,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/arktype": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.1.19.tgz",
+      "integrity": "sha512-notORSuTSpfLV7rq0kYC4mTgIVlVR0xQuvtFxOaE9aKiXyON/kgoIBwZZcKeSSb4BebNcfJoGlxJicAUl/HMdw==",
+      "dependencies": {
+        "@ark/schema": "0.45.9",
+        "@ark/util": "0.45.9"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -443,6 +443,7 @@
   "dependencies": {
     "@vscode/codicons": "^0.0.36",
     "ansi-regex": "^6.1.0",
+    "arktype": "^2.1.19",
     "cross-spawn": "^7.0.6",
     "logform": "^2.7.0",
     "triple-beam": "^1.4.1",

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -1,17 +1,13 @@
 import { Uri } from "vscode";
+import { type } from "arktype";
 
-export interface JJUriParams {
-  rev: string;
-}
+const RevUriParams = type({ rev: "string" });
+const DiffOriginalRevUriParams = type({
+  diffOriginalRev: "string",
+});
+const JJUriParams = type(RevUriParams, "|", DiffOriginalRevUriParams);
 
-function isJJUriParams(params: unknown): params is JJUriParams {
-  return (
-    typeof params === "object" &&
-    params !== null &&
-    Object.hasOwnProperty.call(params, "rev") &&
-    typeof (params as { rev: unknown }).rev === "string"
-  );
-}
+export type JJUriParams = typeof JJUriParams.infer;
 
 /**
  * Use this for any URI that will go to JJFileSystemProvider.
@@ -27,8 +23,8 @@ export function getRev(uri: Uri) {
   if (uri.query === "") {
     throw new Error("URI has no query");
   }
-  const parsed = JSON.parse(uri.query) as unknown;
-  if (!isJJUriParams(parsed)) {
+  const parsed = RevUriParams(JSON.parse(uri.query));
+  if (parsed instanceof type.errors) {
     throw new Error("URI query is not JJUriParams");
   }
   return parsed.rev;
@@ -38,8 +34,8 @@ export function getRevOpt(uri: Uri) {
   if (uri.query === "") {
     return;
   }
-  const parsed = JSON.parse(uri.query) as unknown;
-  if (!isJJUriParams(parsed)) {
+  const parsed = RevUriParams(JSON.parse(uri.query));
+  if (parsed instanceof type.errors) {
     return;
   }
   return parsed.rev;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"module": "Node16",
+		"module": "Preserve",
 		"target": "ES2022",
 		"lib": [
 			"ES2022"
@@ -13,6 +13,7 @@
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+		"moduleResolution": "bundler"
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
Rather than specifying a file at a certain rev, this new kind of URI specifies a file _on the left side of the diff for the specified rev_. In practice "the left side of the diff for the specified rev" will either be a parent rev if there's only one parent, or the merge of all parent revs if there are multiple parents. The merge of all parent revs is not itself a rev, and yet the URI specifies a file in that merged state. I chose to make this a new kind of URI with a field that's named something other than `rev` to try to force our uses of these URIs to confront that distinction. 