### PR TITLE
Implement diff for merge commits

### DIFF
--- a/src/decorationProvider.ts
+++ b/src/decorationProvider.ts
@@ -120,7 +120,11 @@ export class JJDecorationProvider implements FileDecorationProvider {
         "provideFileDecoration was called before data was available",
       );
     }
-    const rev = getRevOpt(uri) ?? "@";
+    const revParam = getRevOpt(uri);
+    if (uri.scheme === "jj" && revParam === undefined) {
+      return undefined;
+    }
+    const rev = revParam ?? "@";
     const key = getKey(uri.fsPath, rev);
     if (rev === "@" && !this.decorations.has(key)) {
       const fsPath =

--- a/src/decorationProvider.ts
+++ b/src/decorationProvider.ts
@@ -7,7 +7,7 @@ import {
   ThemeColor,
 } from "vscode";
 import { FileStatus, FileStatusType } from "./repository";
-import { getRevOpt, toJJUri } from "./uri";
+import { getParams, toJJUri } from "./uri";
 
 const colorOfType = (type: FileStatusType) => {
   switch (type) {
@@ -120,11 +120,16 @@ export class JJDecorationProvider implements FileDecorationProvider {
         "provideFileDecoration was called before data was available",
       );
     }
-    const revParam = getRevOpt(uri);
-    if (uri.scheme === "jj" && revParam === undefined) {
-      return undefined;
+    let rev = "@";
+    if (uri.scheme === "jj") {
+      const params = getParams(uri);
+      if ("diffOriginalRev" in params) {
+        // It doesn't make sense to show a decoration for the left side of a diff, even if that left side is a
+        // single rev, because we never show the left side of a diff by itself; it'll always be part of a diff view.
+        return undefined;
+      }
+      rev = params.rev;
     }
-    const rev = revParam ?? "@";
     const key = getKey(uri.fsPath, rev);
     if (rev === "@" && !this.decorations.has(key)) {
       const fsPath =

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1150,19 +1150,19 @@ export class JJRepository {
       );
     }
 
-    const summaryLine = summaryLines[0].trim();
-    // Check if the file was modified (as opposed to added or deleted)
-    if (/^M\s+/.test(summaryLine)) {
-      const filePath = summaryLine.slice(2).trim();
-      const fullPath = path.join(leftFolderPath, filePath);
+    try {
+      const summaryLine = summaryLines[0].trim();
+      // Check if the file was modified (as opposed to added or deleted)
+      if (/^M\s+/.test(summaryLine)) {
+        const filePath = summaryLine.slice(2).trim();
+        const fullPath = path.join(leftFolderPath, filePath);
 
-      try {
         return await fs.readFile(fullPath);
-      } finally {
-        process.kill(parseInt(fakeEditorPID));
+      } else {
+        return undefined;
       }
-    } else {
-      return undefined;
+    } finally {
+      process.kill(parseInt(fakeEditorPID));
     }
   }
 }

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -29,14 +29,3 @@ export function getParams(uri: Uri) {
   }
   return parsed;
 }
-
-export function getRevOpt(uri: Uri) {
-  if (uri.query === "") {
-    return;
-  }
-  const parsed = RevUriParams(JSON.parse(uri.query));
-  if (parsed instanceof type.errors) {
-    return;
-  }
-  return parsed.rev;
-}

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -19,15 +19,15 @@ export function toJJUri(uri: Uri, params: JJUriParams): Uri {
   });
 }
 
-export function getRev(uri: Uri) {
+export function getParams(uri: Uri) {
   if (uri.query === "") {
     throw new Error("URI has no query");
   }
-  const parsed = RevUriParams(JSON.parse(uri.query));
+  const parsed = JJUriParams(JSON.parse(uri.query));
   if (parsed instanceof type.errors) {
     throw new Error("URI query is not JJUriParams");
   }
-  return parsed.rev;
+  return parsed;
 }
 
 export function getRevOpt(uri: Uri) {


### PR DESCRIPTION
Every place that uses URIs now needs to check whether the URI refers to a specific rev, or if it refers to the left side of a diff and handle those cases accordingly.

This feature uses the fakeeditor we've recently introduced by passing it to `jj diff`.