### PR TITLE
Change title of parent resource states to be the changeId instead of "(Parent Change)"

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -485,7 +485,7 @@ class RepositorySourceControlManager {
               toJJUri(vscode.Uri.file(parentStatus.path), {
                 rev: parentChange.changeId,
               }),
-              "(Parent Change)",
+              `(${parentChange.changeId})`,
             ),
           };
         },


### PR DESCRIPTION
Since the diff does not update when you move the working copy around, I think just having the change id in the title is less confusing and will make it clearer why the diff doesn't update.