### PR TITLE
Hide incompatible commands from the command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,6 +324,80 @@
           "when": "scmProvider == jj",
           "group": "inline"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "jj.openFileResourceState",
+          "when": "false"
+        },
+        {
+          "command": "jj.openFileEditor",
+          "when": "false"
+        },
+        {
+          "command": "jj.openDiffEditor",
+          "when": "false"
+        },
+        {
+          "command": "jj.describe",
+          "when": "false"
+        },
+        {
+          "command": "jj.squashToParentResourceGroup",
+          "when": "false"
+        },
+        {
+          "command": "jj.squashToWorkingCopyResourceGroup",
+          "when": "false"
+        },
+        {
+          "command": "jj.squashToParentResourceState",
+          "when": "false"
+        },
+        {
+          "command": "jj.squashToWorkingCopyResourceState",
+          "when": "false"
+        },
+        {
+          "command": "jj.editResourceGroup",
+          "when": "false"
+        },
+        {
+          "command": "jj.restoreResourceState",
+          "when": "false"
+        },
+        {
+          "command": "jj.restoreResourceGroup",
+          "when": "false"
+        },
+        {
+          "command": "jj.selectOperationLogRepo",
+          "when": "false"
+        },
+        {
+          "command": "jj.operationUndo",
+          "when": "false"
+        },
+        {
+          "command": "jj.operationRestore",
+          "when": "false"
+        },
+        {
+          "command": "jj.selectGraphWebviewRepo",
+          "when": "false"
+        },
+        {
+          "command": "jj.placeholderForFolders",
+          "when": "false"
+        },
+        {
+          "command": "jj.openParentChange",
+          "when": "false"
+        },
+        {
+          "command": "jj.openChildChange",
+          "when": "false"
+        }
       ]
     },
     "configuration": {


### PR DESCRIPTION
Commands Hidden:
- jj.openFileResourceState
- jj.openFileEditor
- jj.openDiffEditor
- jj.describe
- jj.squashToParentResourceGroup
- jj.squashToWorkingCopyResourceGroup
- jj.squashToParentResourceState
- jj.squashToWorkingCopyResourceState
- jj.editResourceGroup
- jj.restoreResourceState
- jj.restoreResourceGroup
- jj.selectOperationLogRepo
- jj.operationRestore
- jj.selectGraphWebviewRepo
- jj.placeholderForFolders
- jj.openParentChange
- jj.openChildChange
- +jj.operationUndo

Remaining Commands:
- jj.refresh
- jj.new
- jj.gitFetch
- jj.refreshOperationLog
- ~jj.operationUndo~
- jj.refreshGraphWebview
- jj.newGraphWebview
- jj.squashSelectedRanges