### PR TITLE
Use end of output sentinel from fakeeditor

### DIFF
--- a/src/fakeeditor/src/main.zig
+++ b/src/fakeeditor/src/main.zig
@@ -27,6 +27,7 @@ pub fn main() !void {
     for (args) |arg| {
         try stdout.print("{s}\n", .{arg});
     }
+    try stdout.print("FAKEEDITOR_OUTPUT_END\n", .{});
 
     _ = c.signal(c.SIGINT, signalHandlerSIGINT);
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -868,13 +868,28 @@ export class JJRepository {
         },
       );
 
+      let fakeEditorOutputBuffer = "";
+      const FAKEEDITOR_SENTINEL = "FAKEEDITOR_OUTPUT_END\n";
+
       childProcess.stdout!.on("data", (data: Buffer) => {
-        const output = data.toString();
+        fakeEditorOutputBuffer += data.toString();
+
+        if (!fakeEditorOutputBuffer.includes(FAKEEDITOR_SENTINEL)) {
+          // Wait for more data if sentinel not yet received
+          return;
+        }
+
+        const output = fakeEditorOutputBuffer.substring(
+          0,
+          fakeEditorOutputBuffer.indexOf(FAKEEDITOR_SENTINEL),
+        );
 
         const lines = output.trim().split("\n");
         const fakeEditorPID = lines[0];
+        // lines[1] is the fakeeditor executable path, which we don't need here
         const leftFolderPath = lines[2];
         const rightFolderPath = lines[3];
+
         if (lines.length !== 4) {
           if (fakeEditorPID) {
             try {


### PR DESCRIPTION
This should fix the intermittent "Unexpected output from fakeeditor" errors that I've been seeing. I think the cause was that I wasn't properly handling the possibility where the output comes in from two different "data" events.