### PR TITLE
Fix tab name when switching from diff to file view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -372,7 +372,26 @@ export async function activate(context: vscode.ExtensionContext) {
         "jj.openFileEditor",
         async (uri: vscode.Uri) => {
           try {
-            await vscode.commands.executeCommand("vscode.open", uri, {});
+            if (!["file", "jj"].includes(uri.scheme)) {
+              return undefined;
+            }
+
+            let rev = "@";
+            if (uri.scheme === "jj") {
+              const params = getParams(uri);
+              if ("diffOriginalRev" in params) {
+                rev = params.diffOriginalRev;
+              } else {
+                rev = params.rev;
+              }
+            }
+
+            await vscode.commands.executeCommand(
+              "vscode.open",
+              uri,
+              {},
+              `${path.basename(uri.fsPath)} (${rev.substring(0, 8)})`,
+            );
           } catch (error) {
             vscode.window.showErrorMessage(
               `Failed to open file${error instanceof Error ? `: ${error.message}` : ""}`,


### PR DESCRIPTION
Before this PR, if you start off in diff view, move to a child change, then switch to file view, the tab will be missing the rev in its title.