### PR TITLE
Pass relative filepath to jj in `getDiffOriginal`

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1234,7 +1234,15 @@ export class JJRepository {
   ): Promise<Buffer | undefined> {
     const output = await new Promise<string>((resolve, reject) => {
       const childProcess = spawnJJ(
-        ["diff", "--summary", "--tool", fakeEditorPath, "-r", rev, filepath],
+        [
+          "diff",
+          "--summary",
+          "--tool",
+          fakeEditorPath,
+          "-r",
+          rev,
+          path.relative(this.repositoryRoot, filepath),
+        ],
         {
           timeout: 5000,
           cwd: this.repositoryRoot,


### PR DESCRIPTION
Related to https://github.com/keanemind/jjk/commit/6d57db151ad06813edb3883b7d2e38c9a19f9675. All filepaths that go to jj must be made relative to avoid introducing colons on Windows, because in Windows absolute paths, drive letters are followed by colons.