### PR TITLE
Escape backslashes in TOML passed to `jj squash`

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -859,7 +859,7 @@ export class JJRepository {
           toRev,
           "--interactive",
           "--config-toml",
-          `ui.diff-editor = "${fakeEditorPath}"`,
+          `ui.diff-editor = "${fakeEditorPath.replaceAll("\\", "\\\\")}"`,
           "--use-destination-message",
         ],
         {


### PR DESCRIPTION
The [TOML spec](https://toml.io/en/v1.0.0#string) says only
> quotation mark, backslash, and the control characters other than tab (U+0000 to U+0008, U+000A to U+001F, U+007F)

need to be escaped. I think of those, only backslashes can appear in filepaths (on Windows). 