### PR TITLE
Fix fakeeditor for Windows

### DIFF
--- a/src/fakeeditor/src/main.zig
+++ b/src/fakeeditor/src/main.zig
@@ -46,14 +46,28 @@ pub fn main() !void {
     _ = c.signal(c.SIGTERM, signalHandlerSIGTERM);
 
     if (builtin.os.tag == .windows) {
+        var overlapped: c.OVERLAPPED = std.mem.zeroes(c.OVERLAPPED);
+        overlapped.hEvent = c.CreateEventA(
+            null, // lpEventAttributes
+            1, // bManualReset (TRUE)
+            0, // bInitialState (FALSE)
+            null, // lpName
+        );
+        // CreateEventA returns NULL on failure.
+        if (overlapped.hEvent == null) {
+            std.debug.print("Failed to create event: {}\n", .{c.GetLastError()});
+            std.process.exit(1);
+        }
+        defer _ = c.CloseHandle(overlapped.hEvent);
+
         const hPipe = c.CreateFileA(
             pipePath.ptr,
-            c.GENERIC_READ | c.GENERIC_WRITE,
-            0,
-            null,
+            c.GENERIC_READ | c.GENERIC_WRITE, // Keep original access mode
+            0, // dwShareMode (0 for exclusive access)
+            null, // lpSecurityAttributes
             c.OPEN_EXISTING,
-            0,
-            null,
+            c.FILE_FLAG_OVERLAPPED, // Enable overlapped I/O
+            null, // hTemplateFile
         );
         if (hPipe == c.INVALID_HANDLE_VALUE) {
             std.debug.print("Failed to connect to pipe: {}\n", .{c.GetLastError()});
@@ -61,14 +75,67 @@ pub fn main() !void {
         }
         defer _ = c.CloseHandle(hPipe);
 
-        // Wait for "EXIT" command on the pipe
         var readBuf: [16]u8 = undefined;
-        var bytesRead: c.DWORD = undefined;
-        _ = c.ReadFile(hPipe, &readBuf, readBuf.len, &bytesRead, null);
+        var bytesRead: c.DWORD = 0;
 
-        const cmd = readBuf[0..bytesRead];
-        if (std.mem.eql(u8, cmd, "EXIT\n")) {
-            std.process.exit(0);
+        // Initiate an overlapped read.
+        // For ReadFile with overlapped I/O, the lpNumberOfBytesRead param must be NULL if lpOverlapped is not NULL.
+        const read_requested = c.ReadFile(hPipe, &readBuf, readBuf.len, null, &overlapped);
+
+        if (read_requested == 0) { // BOOL is 0 for FALSE
+            const last_error = c.GetLastError();
+            if (last_error == c.ERROR_IO_PENDING) {
+                // Operation is pending, wait for it or timeout
+                const wait_timeout_ms: c.DWORD = 5000;
+                const wait_status = c.WaitForSingleObject(overlapped.hEvent, wait_timeout_ms);
+
+                if (wait_status == c.WAIT_OBJECT_0) {
+                    // Operation completed. Get the result.
+                    // bWait = FALSE because WaitForSingleObject already ensured completion.
+                    if (c.GetOverlappedResult(hPipe, &overlapped, &bytesRead, 0) == 0) { // WINBOOL FALSE
+                        std.debug.print("GetOverlappedResult failed after wait: {}\n", .{c.GetLastError()});
+                        std.process.exit(1);
+                    }
+                    // bytesRead is now populated.
+                } else if (wait_status == c.WAIT_TIMEOUT) {
+                    std.debug.print("Timeout waiting for EXIT command on pipe (Windows)\n", .{});
+                    // Attempt to cancel the pending I/O operation.
+                    _ = c.CancelIoEx(hPipe, &overlapped);
+                    std.process.exit(1);
+                } else { // WAIT_FAILED or other unexpected status
+                    std.debug.print("WaitForSingleObject failed: {}\n", .{c.GetLastError()});
+                    std.process.exit(1);
+                }
+            } else {
+                // ReadFile failed immediately for a reason other than ERROR_IO_PENDING.
+                std.debug.print("ReadFile failed immediately: {}\n", .{last_error});
+                std.process.exit(1);
+            }
+        } else {
+            // ReadFile completed synchronously. Get the result.
+            // bWait = FALSE as it completed synchronously.
+            if (c.GetOverlappedResult(hPipe, &overlapped, &bytesRead, 0) == 0) { // WINBOOL FALSE
+                std.debug.print("GetOverlappedResult failed after synchronous read: {}\n", .{c.GetLastError()});
+                std.process.exit(1);
+            }
+            // bytesRead is now populated.
+        }
+
+        // At this point, if we haven't exited, the read operation (if successful) has completed.
+        // Check if any bytes were read and if it's the EXIT command.
+        if (bytesRead > 0) {
+            const cmd = readBuf[0..bytesRead];
+            if (std.mem.eql(u8, cmd, "EXIT\n")) {
+                std.process.exit(0);
+            } else {
+                std.debug.print("Received non-EXIT command: {s} (Windows)\n", .{cmd});
+                std.process.exit(1);
+            }
+        } else {
+            // Read 0 bytes (e.g., pipe closed by writer before EXIT was sent, or other issues).
+            // Timeout case is handled above. This handles successful read of zero bytes.
+            std.debug.print("Read 0 bytes or pipe closed before EXIT (Windows)\n", .{});
+            std.process.exit(1);
         }
     } else {
         // On Unix, open the pipe for reading
@@ -78,18 +145,67 @@ pub fn main() !void {
         };
         defer file.close();
 
-        var readBuf: [16]u8 = undefined;
-        const bytesRead = file.read(&readBuf) catch |err| {
-            std.debug.print("Failed to read from pipe: {}\n", .{err});
+        // Get the file descriptor for polling
+        const fd = file.handle;
+
+        var poll_fds = [_]std.posix.pollfd{
+            .{
+                .fd = fd,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            },
+        };
+
+        // Poll for 5 seconds (5000 milliseconds)
+        const poll_timeout_ms: i32 = 5000;
+        const num_events = std.posix.poll(&poll_fds, poll_timeout_ms) catch |err| {
+            std.debug.print("Failed to poll pipe (std.posix.poll): {}\n", .{err});
             std.process.exit(1);
         };
 
-        const cmd = readBuf[0..bytesRead];
-        if (std.mem.eql(u8, cmd, "EXIT\n")) {
-            std.process.exit(0);
+        if (num_events == 0) {
+            // Timeout occurred
+            std.debug.print("Timeout waiting for EXIT command on pipe (Unix)\n", .{});
+            std.process.exit(1);
+        }
+
+        // Check if our file descriptor has input events
+        if (poll_fds[0].revents & std.posix.POLL.IN != 0) {
+            var readBuf: [16]u8 = undefined;
+            const bytesRead = file.read(&readBuf) catch |err| {
+                std.debug.print("Failed to read from pipe: {}\n", .{err});
+                std.process.exit(1);
+            };
+
+            if (bytesRead > 0) {
+                const cmd = readBuf[0..bytesRead];
+                if (std.mem.eql(u8, cmd, "EXIT\n")) {
+                    std.process.exit(0);
+                } else {
+                    std.debug.print("Received non-EXIT command: {s} (Unix)\n", .{cmd});
+                    std.process.exit(1);
+                }
+            } else {
+                // Read 0 bytes (e.g., pipe closed by writer).
+                std.debug.print("Read 0 bytes or pipe closed before EXIT (Unix)\n", .{});
+                std.process.exit(1);
+            }
+        } else {
+            // Poll returned > 0, but not for POLLIN, or an error/hangup occurred on the fd.
+            if (poll_fds[0].revents & std.posix.POLL.ERR != 0 or
+                poll_fds[0].revents & std.posix.POLL.HUP != 0 or
+                poll_fds[0].revents & std.posix.POLL.NVAL != 0)
+            {
+                std.debug.print("Pipe error, hangup, or invalid fd during poll (Unix)\n", .{});
+            } else {
+                std.debug.print("Poll returned ready, but not for input (Unix), revents: {}\n", .{poll_fds[0].revents});
+            }
+            std.process.exit(1);
         }
     }
 
-    // If we reach here, timeout without receiving EXIT command
+    // If control flow reaches here, it means an unexpected state or an unhandled case.
+    // All expected paths (success, timeout, error, non-EXIT command) should exit above.
+    std.debug.print("Reached end of main unexpectedly.\n", .{});
     std.process.exit(1);
 }

--- a/src/fakeeditor/src/main.zig
+++ b/src/fakeeditor/src/main.zig
@@ -29,17 +29,20 @@ pub fn main() !void {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    if (args.len < 2) {
-        std.debug.print("Error: Named pipe path argument is required\n", .{});
-        std.process.exit(1);
-    }
-
-    // First argument after executable is pipe path
-    const pipePath = args[1];
-
     for (args) |arg| {
         try stdout.print("{s}\n", .{arg});
     }
+
+    var pipePath: []const u8 = undefined; // This will hold the pipe path slice to be used
+
+    const envVarName = "JJ_FAKEEDITOR_PIPE_PATH";
+    const env_pipe_path_owned = std.process.getEnvVarOwned(allocator, envVarName) catch |err| {
+        std.debug.print("Error getting environment variable '{s}': {any}\n", .{ envVarName, err });
+        std.process.exit(1);
+    };
+    pipePath = env_pipe_path_owned;
+    defer allocator.free(env_pipe_path_owned);
+
     try stdout.print("FAKEEDITOR_OUTPUT_END\n", .{});
 
     // Set up SIGTERM handler for failure cases

--- a/src/fakeeditor/src/main.zig
+++ b/src/fakeeditor/src/main.zig
@@ -9,11 +9,6 @@ const c = @cImport({
     }
 });
 
-// Keep SIGTERM handler for failure cases
-fn signalHandlerSIGTERM(_: c_int) callconv(.C) void {
-    std.process.exit(1);
-}
-
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
     const allocator = std.heap.page_allocator;
@@ -44,9 +39,6 @@ pub fn main() !void {
     defer allocator.free(env_pipe_path_owned);
 
     try stdout.print("FAKEEDITOR_OUTPUT_END\n", .{});
-
-    // Set up SIGTERM handler for failure cases
-    _ = c.signal(c.SIGTERM, signalHandlerSIGTERM);
 
     if (builtin.os.tag == .windows) {
         var overlapped: c.OVERLAPPED = std.mem.zeroes(c.OVERLAPPED);

--- a/src/fakeeditor/src/main.zig
+++ b/src/fakeeditor/src/main.zig
@@ -3,15 +3,20 @@ const builtin = @import("builtin");
 const c = @cImport({
     @cInclude("signal.h");
     @cInclude("stdlib.h");
+    // Windows-specific includes for named pipes
+    if (builtin.os.tag == .windows) {
+        @cInclude("windows.h");
+    }
 });
 
-// Exit with 0 on SIGINT (success signal from extension)
-fn signalHandlerSIGINT(_: c_int) callconv(.C) void {
-    std.process.exit(0);
+// Keep SIGTERM handler for failure cases
+fn signalHandlerSIGTERM(_: c_int) callconv(.C) void {
+    std.process.exit(1);
 }
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
+    const allocator = std.heap.page_allocator;
 
     const pid = switch (builtin.os.tag) {
         .linux => std.os.linux.getpid(),
@@ -21,21 +26,70 @@ pub fn main() !void {
     };
     try stdout.print("{}\n", .{pid});
 
-    const args = try std.process.argsAlloc(std.heap.page_allocator);
-    defer std.process.argsFree(std.heap.page_allocator, args);
-    
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len < 2) {
+        std.debug.print("Error: Named pipe path argument is required\n", .{});
+        std.process.exit(1);
+    }
+
+    // First argument after executable is pipe path
+    const pipePath = args[1];
+
     for (args) |arg| {
         try stdout.print("{s}\n", .{arg});
     }
     try stdout.print("FAKEEDITOR_OUTPUT_END\n", .{});
 
-    _ = c.signal(c.SIGINT, signalHandlerSIGINT);
+    // Set up SIGTERM handler for failure cases
+    _ = c.signal(c.SIGTERM, signalHandlerSIGTERM);
 
-    // Keep the program running until a signal is received or 5 seconds pass
-    var seconds: u32 = 0;
-    while (seconds < 5) : (seconds += 1) {
-        std.time.sleep(1 * std.time.ns_per_s);
+    if (builtin.os.tag == .windows) {
+        const hPipe = c.CreateFileA(
+            pipePath.ptr,
+            c.GENERIC_READ | c.GENERIC_WRITE,
+            0,
+            null,
+            c.OPEN_EXISTING,
+            0,
+            null,
+        );
+        if (hPipe == c.INVALID_HANDLE_VALUE) {
+            std.debug.print("Failed to connect to pipe: {}\n", .{c.GetLastError()});
+            std.process.exit(1);
+        }
+        defer _ = c.CloseHandle(hPipe);
+
+        // Wait for "EXIT" command on the pipe
+        var readBuf: [16]u8 = undefined;
+        var bytesRead: c.DWORD = undefined;
+        _ = c.ReadFile(hPipe, &readBuf, readBuf.len, &bytesRead, null);
+
+        const cmd = readBuf[0..bytesRead];
+        if (std.mem.eql(u8, cmd, "EXIT\n")) {
+            std.process.exit(0);
+        }
+    } else {
+        // On Unix, open the pipe for reading
+        const file = std.fs.cwd().openFile(pipePath, .{ .mode = .read_only }) catch |err| {
+            std.debug.print("Failed to open pipe: {}\n", .{err});
+            std.process.exit(1);
+        };
+        defer file.close();
+
+        var readBuf: [16]u8 = undefined;
+        const bytesRead = file.read(&readBuf) catch |err| {
+            std.debug.print("Failed to read from pipe: {}\n", .{err});
+            std.process.exit(1);
+        };
+
+        const cmd = readBuf[0..bytesRead];
+        if (std.mem.eql(u8, cmd, "EXIT\n")) {
+            std.process.exit(0);
+        }
     }
-    // If loop finishes, it means no SIGINT/SIGTERM was received; exit with 1 (timeout)
+
+    // If we reach here, timeout without receiving EXIT command
     std.process.exit(1);
 }


### PR DESCRIPTION
The previous iteration of fakeeditor relied on POSIX signals to know whether it should exit with code 0 or not. That mechanism of communication didn't seem to work properly on Windows. We're now moving to using named pipes with more OS-specific code to communicate. 