### PR TITLE
Fix command when clauses to use `jj.reposExist` instead of `scmProvider == jj`

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,33 +191,33 @@
       "editor/title": [
         {
           "command": "jj.squashSelectedRanges",
-          "when": "scmProvider == jj && editorTextFocus && editorHasSelection && !editorReadonly"
+          "when": "jj.reposExist && editorTextFocus && editorHasSelection && !editorReadonly"
         },
         {
           "command": "jj.openFileEditor",
-          "when": "scmProvider == jj && isInDiffEditor",
+          "when": "jj.reposExist && isInDiffEditor",
           "group": "navigation"
         },
         {
           "command": "jj.openDiffEditor",
-          "when": "scmProvider == jj && !isInDiffEditor",
+          "when": "jj.reposExist && !isInDiffEditor",
           "group": "navigation@1"
         },
         {
           "command": "jj.openParentChange",
-          "when": "scmProvider == jj",
+          "when": "jj.reposExist",
           "group": "navigation@2"
         },
         {
           "command": "jj.openChildChange",
-          "when": "scmProvider == jj",
+          "when": "jj.reposExist",
           "group": "navigation@3"
         }
       ],
       "editor/context": [
         {
           "command": "jj.squashSelectedRanges",
-          "when": "scmProvider == jj && editorTextFocus && editorHasSelection && !editorReadonly"
+          "when": "jj.reposExist && editorTextFocus && editorHasSelection && !editorReadonly"
         }
       ],
       "view/title": [


### PR DESCRIPTION
`scmProvider == jj` is only true when you actively have the source control view open.