### PR TITLE
Watch operation log to replace all polling except for one command used for snapshotting

### DIFF
--- a/src/fileSystemProvider.ts
+++ b/src/fileSystemProvider.ts
@@ -46,12 +46,7 @@ export class JJFileSystemProvider implements FileSystemProvider {
 
   dispose() {}
 
-  onDidChangeRepository({
-    repositoryRoot,
-  }: {
-    uri: Uri;
-    repositoryRoot: string;
-  }): void {
+  onDidChangeRepository({ repositoryRoot }: { repositoryRoot: string }): void {
     this.changedRepositoryRoots.add(repositoryRoot);
     void this.fireChangeEvents();
   }

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -108,10 +108,14 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
     await this.refresh();
   }
 
-  public setSelectedRepository(repo: JJRepository) {
+  public async setSelectedRepository(repo: JJRepository) {
+    const prevRepo = this.repository;
     this.repository = repo;
     if (this.panel) {
       this.panel.title = `Source Control Graph (${path.basename(this.repository.repositoryRoot)})`;
+    }
+    if (prevRepo.repositoryRoot !== repo.repositoryRoot) {
+      await this.refresh();
     }
   }
 

--- a/src/operationLogTreeView.ts
+++ b/src/operationLogTreeView.ts
@@ -38,6 +38,10 @@ export class OperationLogManager {
     )})`;
   }
 
+  async refresh() {
+    await this.operationLogTreeDataProvider.refresh();
+  }
+
   dispose() {
     this.subscriptions.forEach((s) => s.dispose());
   }
@@ -95,8 +99,11 @@ export class OperationLogTreeDataProvider implements TreeDataProvider<unknown> {
   }
 
   async setSelectedRepo(repo: JJRepository) {
+    const prevRepo = this.selectedRepository;
     this.selectedRepository = repo;
-    await this.refresh();
+    if (prevRepo.repositoryRoot !== repo.repositoryRoot) {
+      await this.refresh();
+    }
   }
 
   getSelectedRepo() {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -497,9 +497,9 @@ class RepositorySourceControlManager {
     );
   }
 
-  async checkForUpdates(force = false) {
+  async checkForUpdates() {
     if (!this.checkForUpdatesPromise) {
-      this.checkForUpdatesPromise = this.checkForUpdatesUnsafe(force);
+      this.checkForUpdatesPromise = this.checkForUpdatesUnsafe();
       try {
         await this.checkForUpdatesPromise;
       } finally {
@@ -513,9 +513,9 @@ class RepositorySourceControlManager {
   /**
    * This should never be called concurrently.
    */
-  async checkForUpdatesUnsafe(force: boolean) {
+  async checkForUpdatesUnsafe() {
     const latestOperationId = await this.repository.getLatestOperationId();
-    if (force || this.operationId !== latestOperationId) {
+    if (this.operationId !== latestOperationId) {
       this.operationId = latestOperationId;
       const status = await this.repository.status();
 


### PR DESCRIPTION
This makes jjk much more responsive to repository updates that happened outside of jjk, such as from the command line.