### PR TITLE
Quick fix for operation log and graph view holding onto stale repository instances

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,10 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.workspace.onDidChangeWorkspaceFolders(
     async () => {
       logger.info("Workspace folders changed");
-      await workspaceSCM.refresh();
+      const didUpdate = await workspaceSCM.refresh();
+      if (didUpdate) {
+        setSelectedRepo(getSelectedRepo());
+      }
       await checkReposFunction();
     },
     undefined,
@@ -1404,7 +1407,10 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   async function poll() {
-    await workspaceSCM.refresh();
+    const didUpdate = await workspaceSCM.refresh();
+    if (didUpdate) {
+      setSelectedRepo(getSelectedRepo());
+    }
     if (workspaceSCM.repoSCMs.length > 0) {
       vscode.commands.executeCommand("setContext", "jj.reposExist", true);
       if (!isInitialized) {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -401,6 +401,7 @@ export class WorkspaceSourceControlManager {
       }
       this.repoSCMs = repoSCMs;
     }
+    return isAnyRepoChanged;
   }
 
   getRepositoryFromUri(uri: vscode.Uri) {


### PR DESCRIPTION
This issue has always existed but is easier to encounter now after https://github.com/keanemind/jjk/pull/132