### PR TITLE
Add a files exclusion setting for .jj

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,6 +429,11 @@
         }
       }
     },
+    "configurationDefaults": {
+      "files.exclude": {
+        "**/.jj": true
+      }
+    },
     "colors": [
       {
         "id": "jjDecoration.addedResourceForeground",


### PR DESCRIPTION
Fix #84

Turns out that VSCode has a really easy way to achieve this.

Preview of what the settings look like with this change
![Image](https://github.com/user-attachments/assets/b34da062-195e-4cd9-9d5f-c7650a37f6e4)