### PR TITLE
Fix rendering descriptions with html entities

### DIFF
--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -361,10 +361,13 @@
                 // Create text content container
                 const textContent = document.createElement('div');
                 textContent.className = 'text-content';
-                textContent.innerHTML = `
-                    <div>${change.label}</div>
-                    <div class="description">${change.description}</div>
-                `;
+                const nodeLabel = document.createElement("div");
+                nodeLabel.textContent = change.label;
+                textContent.append(nodeLabel);
+                const nodeDescription = document.createElement("div");
+                nodeDescription.className = 'description';
+                nodeDescription.textContent = change.description;
+                textContent.append(nodeDescription);
                 node.appendChild(textContent);
 
                 // Create and append edit button


### PR DESCRIPTION
Fix #140

This makes sure that any jj description will only ever be rendered as text, and never be interpreted specially.

e.g.
![image](https://github.com/user-attachments/assets/5c63cb9e-e244-4550-8c74-6bfa0bafa534)
