### PR TITLE
Prevent Duplicate Repositories

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -325,12 +325,17 @@ export class WorkspaceSourceControlManager {
         )
           .toString()
           .trim();
-        newRepoInfos.set(workspaceFolder.uri.fsPath, {
-          jjPath,
-          jjVersion,
-          jjConfigArgs,
-          repoRoot,
-        });
+
+        const repoUri = vscode.Uri.file(repoRoot.replace(/^\\\\\?\\UNC\\/, "\\\\")).toString();
+
+        if (!newRepoInfos.has(repoUri)) {
+          newRepoInfos.set(repoUri, {
+            jjPath,
+            jjVersion,
+            jjConfigArgs,
+            repoRoot,
+          });
+        }
       } catch (e) {
         if (e instanceof Error && e.message.includes("no jj repo in")) {
           logger.debug(`No jj repo in ${workspaceFolder.uri.fsPath}`);


### PR DESCRIPTION
Currently, workspaces containing folders within the same repository cause the aforementioned repository to occur multiple times in the `Source Control`view.

Changes made in this PR fix this by memorizing the `fsPath` of each repository and ensuring it's only added once.

Changes made in this PR will fix #147