### PR TITLE
repository.ts: add option `jjk.ignoreWorkingCopy`, run on read-only commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -426,6 +426,12 @@
           "default": "",
           "description": "Path to the jj executable. If not set, your PATH and common locations will be searched for a jj executable.",
           "scope": "resource"
+        },
+        "jjk.ignoreWorkingCopy": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use --ignore-working-copy for read-only commands to prevent automatic working copy snapshots. This prevents divergent changesets from passive monitoring, but modified files may not auto-update until the next manual jj command.",
+          "scope": "resource"
         }
       }
     },

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -132,6 +132,22 @@ function getCommandTimeout(
 }
 
 /**
+ * Returns ["--ignore-working-copy"] if the setting is enabled, otherwise returns an empty array.
+ * This allows the flag to be conditionally included using the spread operator.
+ */
+function getIgnoreWorkingCopyArgs(repositoryRoot: string): string[] {
+  const config = vscode.workspace.getConfiguration(
+    "jjk",
+    vscode.Uri.file(repositoryRoot),
+  );
+  const ignoreWorkingCopy = config.get<boolean>("ignoreWorkingCopy");
+  if (ignoreWorkingCopy) {
+    return ["--ignore-working-copy"];
+  }
+  return [];
+}
+
+/**
  * Gets the configured jj executable path from settings.
  * If no path is configured, searches through common installation paths before falling back to "jj".
  */
@@ -195,9 +211,9 @@ function spawnJJ(
     timeout: getCommandTimeout(options.cwd, options.timeout),
   };
 
-  logger.debug(`spawn: ${jjPath} ${args.join(" ")}`, {
-    spawnOptions: finalOptions,
-  });
+  logger.info(
+    `spawn: ${JSON.stringify([jjPath, ...args])} ${JSON.stringify({ spawnOptions: finalOptions })}`,
+  );
 
   return spawn(jjPath, args, finalOptions);
 }
@@ -317,16 +333,22 @@ export class WorkspaceSourceControlManager {
 
         const repoRoot = (
           await handleCommand(
-            spawnJJ(jjPath.filepath, ["root"], {
-              timeout: 5000,
-              cwd: workspaceFolder.uri.fsPath,
-            }),
+            spawnJJ(
+              jjPath.filepath,
+              [...getIgnoreWorkingCopyArgs(workspaceFolder.uri.fsPath), "root"],
+              {
+                timeout: 5000,
+                cwd: workspaceFolder.uri.fsPath,
+              },
+            ),
           )
         )
           .toString()
           .trim();
 
-        const repoUri = vscode.Uri.file(repoRoot.replace(/^\\\\\?\\UNC\\/, "\\\\")).toString();
+        const repoUri = vscode.Uri.file(
+          repoRoot.replace(/^\\\\\?\\UNC\\/, "\\\\"),
+        ).toString();
 
         if (!newRepoInfos.has(repoUri)) {
           newRepoInfos.set(repoUri, {
@@ -836,7 +858,16 @@ export class JJRepository {
     return (
       await handleJJCommand(
         this.spawnJJ(
-          ["operation", "log", "--limit", "1", "-T", "self.id()", "--no-graph"],
+          [
+            ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
+            "operation",
+            "log",
+            "--limit",
+            "1",
+            "-T",
+            "self.id()",
+            "--no-graph",
+          ],
           {
             cwd: this.repositoryRoot,
           },
@@ -854,10 +885,13 @@ export class JJRepository {
 
     const output = (
       await handleJJCommand(
-        this.spawnJJ(["status", "--color=always"], {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
-        }),
+        this.spawnJJ(
+          [...getIgnoreWorkingCopyArgs(this.repositoryRoot), "status", "--color=always"],
+          {
+            timeout: 5000,
+            cwd: this.repositoryRoot,
+          },
+        ),
       )
     ).toString();
     const status = await parseJJStatus(this.repositoryRoot, output);
@@ -874,10 +908,13 @@ export class JJRepository {
   async fileList() {
     return (
       await handleJJCommand(
-        this.spawnJJ(["file", "list"], {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
-        }),
+        this.spawnJJ(
+          [...getIgnoreWorkingCopyArgs(this.repositoryRoot), "file", "list"],
+          {
+            timeout: 5000,
+            cwd: this.repositoryRoot,
+          },
+        ),
       )
     )
       .toString()
@@ -922,6 +959,7 @@ export class JJRepository {
       await handleJJCommand(
         this.spawnJJ(
           [
+            ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
             "log",
             "-T",
             template,
@@ -1096,7 +1134,14 @@ export class JJRepository {
   readFile(rev: string, filepath: string) {
     return handleJJCommand(
       this.spawnJJ(
-        ["file", "show", "--revision", rev, filepathToFileset(filepath)],
+        [
+          ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
+          "file",
+          "show",
+          "--revision",
+          rev,
+          filepathToFileset(filepath),
+        ],
         {
           timeout: 5000,
           cwd: this.repositoryRoot,
@@ -1463,6 +1508,7 @@ export class JJRepository {
       await handleJJCommand(
         this.spawnJJ(
           [
+            ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
             "log",
             "-r",
             rev,
@@ -1570,6 +1616,7 @@ export class JJRepository {
       await handleJJCommand(
         this.spawnJJ(
           [
+            ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
             "file",
             "annotate",
             "-r",
@@ -1610,13 +1657,13 @@ export class JJRepository {
       await handleJJCommand(
         this.spawnJJ(
           [
+            ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
             "operation",
             "log",
             "--limit",
             "10",
             "--no-graph",
             "--at-operation=@",
-            "--ignore-working-copy",
             "-T",
             template,
           ],
@@ -1715,7 +1762,15 @@ export class JJRepository {
         // in case the file was renamed or copied. If we knew the status of the file, we could
         // pass the previous filename in addition to the current filename upon seeing a rename or copy.
         // We don't have the status though, which is why we're using `--summary` here.
-        ["diff", "--summary", "--tool", `${fakeEditorPath}`, "-r", rev],
+        [
+          ...getIgnoreWorkingCopyArgs(this.repositoryRoot),
+          "diff",
+          "--summary",
+          "--tool",
+          `${fakeEditorPath}`,
+          "-r",
+          rev,
+        ],
         {
           timeout: 10_000, // Ensure this is longer than fakeeditor's internal timeout
           cwd: this.repositoryRoot,


### PR DESCRIPTION
This mitigates the "stale working copy" issue "divergent changesets" issue.

From a careful reading of
https://jj-vcs.github.io/jj/latest/working-copy/#stale-working-copy, `jj` will always:

1. snapshot the state of the repo
2. run the command
3. check that the state has not changed
   1. if it has not changed, snapshot the new state
   2. if it has changed, put the repo into both(?) the "stale working copy" and "divergent changesets" state.

This can make it pretty easy to get your repo stuck if you do this:
You can reproduce the issue by:
1. `jj describe`, but keep the editor open
2. editing a file
3. wait a few seconds. jjk automatically runs a `jj` command all the time, snapshotting the file change
4. close the `jj describe` editor

Add an option to run all read-only operations with `--ignore-working-copy`. It is disabled by default.

From https://jj-vcs.github.io/jj/latest/cli-reference, this is an option intended for this use case:

> By default, Jujutsu snapshots the working copy at the beginning of every
> command. The working copy is also updated at the end of the command, if the
> command modified the working-copy commit (@). If you want to avoid snapshotting
> the working copy and instead see a possibly stale working-copy commit, you can
> use --ignore-working-copy. This may be useful e.g. in a command prompt,
> especially if you have another process that commits the working copy. This will
> not snapshot file changes, and just use the last snapshot.

The upside is that jjk will never create divergent changes from its passive monitoring.
The downside is that the list of modified files will not auto-update. They will update the next time the user runs a `jj` command (without `--ignore-working-copy`).
Unfortunately there isn't a perfect solution that will auto-update and never create divergent changes. See https://github.com/jj-vcs/jj/issues/2562.
