### PR TITLE
fakeeditor: update to compile on zig 0.15.1

### DIFF
--- a/src/fakeeditor/build.zig
+++ b/src/fakeeditor/build.zig
@@ -29,12 +29,16 @@ pub fn build(b: *std.Build) void {
         }
     }
 
-    const exe = b.addExecutable(.{
-        .name = exe_name,
+    const root_module = b.createModule(.{
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = exe_name,
+        .root_module = root_module,
     });
 
     b.installArtifact(exe);


### PR DESCRIPTION
# Description

fakeeditor doesn't compile on the latest version of zig. Update it so it does!

# Reproduction

```
brew install zig # installs 0.15.1
npm run package
```

# Issues & fix

Trying to build this extension, I got these errors:

```
install
└─ install fakeeditor_macos_aarch64
   └─ compile exe fakeeditor_macos_aarch64 ReleaseSmall aarch64-macos 1 errors
src/main.zig:86:26: error: root source file struct 'Io' has no member named 'getStdOut'
    const stdout = std.io.getStdOut().writer();
                   ~~~~~~^~~~~~~~~~
```

This is no longer defined; just create a stdout local variable and pass it around.

```
build.zig:34:10: error: no field named 'root_source_file' in struct 'Build.ExecutableOptions'
        .root_source_file = b.path("src/main.zig"),
         ^~~~~~~~~~~~~~~~
```

Now you can to call `createModule` with these fields, and then pass that module into `createExecutable`.

Fixes https://github.com/keanemind/jjk/issues/165.