### PR TITLE
deduplicate "build" and "package" npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -568,14 +568,13 @@
     ]
   },
   "scripts": {
-    "build": "tsc && cp -r src/webview dist/ && cp src/config.toml dist/ && npm run build-fakeeditor && mkdir -p dist/fakeeditor/zig-out/bin && cp -r src/fakeeditor/zig-out/bin/. dist/fakeeditor/zig-out/bin/",
+    "build": "npm run check-types && npm run lint && node esbuild.js --production && cp -r src/webview dist/ && cp src/config.toml dist/ && mkdir -p dist/codicons && cp -r node_modules/@vscode/codicons/dist/* dist/codicons/ && npm run build-fakeeditor && mkdir -p dist/fakeeditor/zig-out/bin && cp -r src/fakeeditor/zig-out/bin/. dist/fakeeditor/zig-out/bin/",
     "build-fakeeditor": "cd src/fakeeditor && ./build_all_platforms.sh",
-    "vscode:prepublish": "npm run package",
+    "vscode:prepublish": "npm run build",
     "compile": "npm run check-types && npm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",
     "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-    "package": "npm run check-types && npm run lint && node esbuild.js --production && cp -r src/webview dist/ && cp src/config.toml dist/ && mkdir -p dist/codicons && cp -r node_modules/@vscode/codicons/dist/* dist/codicons/ && npm run build-fakeeditor && mkdir -p dist/fakeeditor/zig-out/bin && cp -r src/fakeeditor/zig-out/bin/. dist/fakeeditor/zig-out/bin/",
     "compile-tests": "node esbuild.js --test",
     "pretest": "npm run compile-tests && npm run compile",
     "check-types": "tsc --noEmit",


### PR DESCRIPTION
The "build" script was previously unused and misleading. I've renamed the "package" script to "build" and got rid of the old "build" script.