### PR TITLE
Fix inconsistent diff editor titles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -465,43 +465,34 @@ export async function activate(context: vscode.ExtensionContext) {
             const rev = params.diffOriginalRev;
 
             const scm =
-              workspaceSCM.getRepositorySourceControlManagerFromUri(uri);
+              workspaceSCM.getRepositorySourceControlManagerFromUri(
+                originalUri,
+              );
+
             if (!scm) {
               throw new Error(
                 "Source Control Manager not found with given URI.",
               );
             }
 
-            const fileStatuses = scm?.fileStatusesByChange.get(rev) || [];
-            const fileStatus = fileStatuses.find((status) =>
-              pathEquals(status.path, uri.fsPath),
+            const repo = workspaceSCM.getRepositoryFromUri(originalUri);
+            if (!repo) {
+              throw new Error("Repository could not be found with given URI.");
+            }
+
+            const { fileStatuses } = await repo.show(rev);
+            const fileStatus = fileStatuses.find((file) =>
+              pathEquals(file.path, originalUri.path),
             );
 
-            if (!fileStatus) {
-              console.log("fileStatus Not found");
-            }
-
-            const repo = workspaceSCM.getRepositoryFromUri(originalUri);
-            console.log("TEST: ", await repo?.show(rev));
-            console.log("REV: ", rev);
-
-            let title = "";
-            const diffTitleSuffix = rev === "@" ? "(Working Copy)" : `(${rev})`;
-            if (fileStatus?.type === "R") {
-              title =
-                (fileStatus.renamedFrom
-                  ? `${fileStatus.renamedFrom} => `
-                  : "") + `${fileStatus.file} ${diffTitleSuffix}`;
-            } else {
-              const label = fileStatus?.file ?? "";
-              title = `${label} ${diffTitleSuffix}`;
-            }
-
+            const diffTitleSuffix =
+              rev === "@" ? "(Working Copy)" : `(${rev.substring(0, 8)})`;
             await vscode.commands.executeCommand(
               "vscode.diff",
               originalUri,
               uri,
-              title,
+              (fileStatus?.renamedFrom ? `${fileStatus.renamedFrom} => ` : "") +
+                `${path.relative(repo.repositoryRoot, originalUri.path)} ${diffTitleSuffix}`,
             );
           } catch (error) {
             vscode.window.showErrorMessage(


### PR DESCRIPTION
Opening a diff by clicking on a resource state can result in a title that's different from what you get if you open the diff by using the "Open diff" command in the editor title menu. The latter seems less correct; it doesn't have the title reflect file renames, for example. The former uses "(Working Copy)" whereas the latter uses "(@)". 

Fixed by using the same format as the "open diff" command when issued from the source control graph.