### PR TITLE
add more flexibility to spawnJJ

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -100,16 +100,18 @@ export function initExtensionDir(extensionUri: vscode.Uri) {
  * Otherwise, returns the provided default timeout, or 30 seconds if no default is provided.
  */
 function getCommandTimeout(
-  repositoryRoot: string,
+  repositoryRoot: string | undefined,
   defaultTimeout: number | undefined,
 ): number {
-  const config = vscode.workspace.getConfiguration(
-    "jjk",
-    vscode.Uri.file(repositoryRoot),
-  );
-  const configuredTimeout = config.get<number | null>("commandTimeout");
-  if (configuredTimeout !== null && configuredTimeout !== undefined) {
-    return configuredTimeout;
+  if (repositoryRoot) {
+    const config = vscode.workspace.getConfiguration(
+      "jjk",
+      vscode.Uri.file(repositoryRoot),
+    );
+    const configuredTimeout = config.get<number | null>("commandTimeout");
+    if (configuredTimeout !== null && configuredTimeout !== undefined) {
+      return configuredTimeout;
+    }
   }
   return defaultTimeout ?? 30000;
 }
@@ -202,12 +204,21 @@ async function getJJPath(
 function spawnJJ(
   jjPath: string,
   args: string[],
-  options: Parameters<typeof spawn>[2] & { cwd: string },
+  options: Parameters<typeof spawn>[2],
+  {
+    repositoryRoot,
+    defaultTimeout,
+  }: {
+    repositoryRoot: string | undefined;
+    defaultTimeout: number | undefined;
+  },
 ) {
   const finalOptions = {
     ...options,
-    timeout: getCommandTimeout(options.cwd, options.timeout),
-  };
+    cwd: options?.cwd ?? repositoryRoot, // precedence: options.cwd > repositoryRoot > undefined
+    timeout:
+      options?.timeout ?? getCommandTimeout(repositoryRoot, defaultTimeout), // precedence: options.timeout > jjk.commandTimeout config > defaultTimeout > 30s
+  } satisfies Parameters<typeof spawn>[2];
 
   logger.info(
     `spawn: ${JSON.stringify([jjPath, ...args])} ${JSON.stringify({ spawnOptions: finalOptions })}`,
@@ -334,10 +345,17 @@ export class WorkspaceSourceControlManager {
 
         const repoRoot = (
           await handleCommand(
-            spawnJJ(jjPath.filepath, ["--ignore-working-copy", "root"], {
-              timeout: 5000,
-              cwd: workspaceFolder.uri.fsPath,
-            }),
+            spawnJJ(
+              jjPath.filepath,
+              ["--ignore-working-copy", "root"],
+              {
+                cwd: workspaceFolder.uri.fsPath,
+              },
+              {
+                repositoryRoot: undefined,
+                defaultTimeout: 5000,
+              },
+            ),
           )
         )
           .toString()
@@ -847,20 +865,25 @@ export class JJRepository {
 
   spawnJJ(
     args: string[],
-    options: Parameters<typeof spawn>[2] & { cwd: string },
+    { defaultTimeout }: { defaultTimeout?: number } = {},
+    options?: Parameters<typeof spawn>[2],
   ) {
     const jjConfigArgs = [
       "--config-file",
       path.join(extensionDir, "config.toml"),
     ];
-    return spawnJJ(this.jjPath, [...args, ...jjConfigArgs], options);
+    return spawnJJ(this.jjPath, [...args, ...jjConfigArgs], options, {
+      repositoryRoot: this.repositoryRoot,
+      defaultTimeout,
+    });
   }
 
   spawnJJRead(
     args: string[],
-    options: Parameters<typeof spawn>[2] & { cwd: string },
+    arg2: { defaultTimeout?: number } = {},
+    options?: Parameters<typeof spawn>[2],
   ) {
-    return this.spawnJJ(["--ignore-working-copy", ...args], options);
+    return this.spawnJJ(["--ignore-working-copy", ...args], arg2, options);
   }
 
   /**
@@ -870,21 +893,16 @@ export class JJRepository {
   async getLatestOperationId() {
     return (
       await handleJJCommand(
-        this.spawnJJ(
-          [
-            ...getPollIgnoreWorkingCopyArgs(this.repositoryRoot),
-            "operation",
-            "log",
-            "--limit",
-            "1",
-            "-T",
-            "self.id()",
-            "--no-graph",
-          ],
-          {
-            cwd: this.repositoryRoot,
-          },
-        ),
+        this.spawnJJ([
+          ...getPollIgnoreWorkingCopyArgs(this.repositoryRoot),
+          "operation",
+          "log",
+          "--limit",
+          "1",
+          "-T",
+          "self.id()",
+          "--no-graph",
+        ]),
       )
     )
       .toString()
@@ -899,8 +917,7 @@ export class JJRepository {
     const output = (
       await handleJJCommand(
         this.spawnJJRead(["status", "--color=always"], {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
+          defaultTimeout: 5000,
         }),
       )
     ).toString();
@@ -919,8 +936,7 @@ export class JJRepository {
     return (
       await handleJJCommand(
         this.spawnJJRead(["file", "list"], {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
+          defaultTimeout: 5000,
         }),
       )
     )
@@ -970,8 +986,7 @@ export class JJRepository {
             ...revsets.flatMap((revset) => ["-r", revset]),
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       )
@@ -1095,8 +1110,7 @@ export class JJRepository {
       this.spawnJJRead(
         ["file", "show", "--revision", rev, filepathToFileset(filepath)],
         {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
+          defaultTimeout: 5000,
         },
       ),
     );
@@ -1131,8 +1145,7 @@ export class JJRepository {
             ...(ignoreImmutable ? ["--ignore-immutable"] : []),
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       )
@@ -1149,8 +1162,7 @@ export class JJRepository {
             ...(revs ? ["-r", ...revs] : []),
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       );
@@ -1236,8 +1248,7 @@ export class JJRepository {
             ...(ignoreImmutable ? ["--ignore-immutable"] : []),
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       )
@@ -1320,8 +1331,9 @@ export class JJRepository {
           ...(ignoreImmutable ? ["--ignore-immutable"] : []),
         ],
         {
-          timeout: 10_000, // Ensure this is longer than fakeeditor's internal timeout
-          cwd: this.repositoryRoot,
+          defaultTimeout: 10_000, // Ensure this is longer than fakeeditor's internal timeout
+        },
+        {
           env: { ...process.env, ...envVars },
         },
       );
@@ -1470,8 +1482,7 @@ export class JJRepository {
             ...(noGraph ? ["--no-graph"] : []),
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       )
@@ -1500,8 +1511,7 @@ export class JJRepository {
       this.spawnJJ(
         ["edit", "-r", rev, ...(ignoreImmutable ? ["--ignore-immutable"] : [])],
         {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
+          defaultTimeout: 5000,
         },
       ),
     );
@@ -1537,8 +1547,7 @@ export class JJRepository {
           ...(ignoreImmutable ? ["--ignore-immutable"] : []),
         ],
         {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
+          defaultTimeout: 5000,
         },
       ),
     );
@@ -1550,8 +1559,7 @@ export class JJRepository {
         try {
           await handleJJCommand(
             this.spawnJJ(["git", "fetch"], {
-              timeout: 60_000,
-              cwd: this.repositoryRoot,
+              defaultTimeout: 60_000,
             }),
           );
         } finally {
@@ -1574,8 +1582,7 @@ export class JJRepository {
             filepath, // `jj file annotate` takes a path, not a fileset
           ],
           {
-            timeout: 60_000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 60_000,
           },
         ),
       )
@@ -1617,8 +1624,7 @@ export class JJRepository {
             template,
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       )
@@ -1684,8 +1690,7 @@ export class JJRepository {
             id,
           ],
           {
-            timeout: 5000,
-            cwd: this.repositoryRoot,
+            defaultTimeout: 5000,
           },
         ),
       )
@@ -1696,8 +1701,7 @@ export class JJRepository {
     return (
       await handleJJCommand(
         this.spawnJJ(["operation", "restore", id], {
-          timeout: 5000,
-          cwd: this.repositoryRoot,
+          defaultTimeout: 5000,
         }),
       )
     ).toString();
@@ -1720,8 +1724,9 @@ export class JJRepository {
         // We don't have the status though, which is why we're using `--summary` here.
         ["diff", "--summary", "--tool", `${fakeEditorPath}`, "-r", rev],
         {
-          timeout: 10_000, // Ensure this is longer than fakeeditor's internal timeout
-          cwd: this.repositoryRoot,
+          defaultTimeout: 10_000, // Ensure this is longer than fakeeditor's internal timeout
+        },
+        {
           env: { ...process.env, ...envVars },
         },
       );


### PR DESCRIPTION
`spawnJJ` now allows you to override the timeout or other spawn arguments if necessary. This will be used by the new `showAllPaginated` repository function upstack. 

Also, `JJRepository.spawnJJ` now defaults to spawning with `cwd: this.repositoryRoot`, which allows us to remove a lot of passing in the `cwd` field.