### PR TITLE
Open working copy on right side of diff view

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -751,9 +751,7 @@ class RepositorySourceControlManager {
                 toJJUri(vscode.Uri.file(parentStatus.path), {
                   diffOriginalRev: parentChange.changeId,
                 }),
-                toJJUri(vscode.Uri.file(parentStatus.path), {
-                  rev: parentChange.changeId,
-                }),
+                vscode.Uri.file(parentStatus.path),
                 `(${parentChange.changeId})`,
               ),
             };


### PR DESCRIPTION
This changes the diff editor to open the working copy of the file on the right side instead of a read-only copy of it. This lets you edit on the right side of the diff view and jump to the file with the "open file" button, as requested in #172.

I tested this out and it seemed to work exactly how I expected. If there was some reason to fetch the content from jj on the right side of the diff instead of reading the file, let me know and I'll try to figure out a different approach.

Fixes #172