### PR TITLE
Show open button on parent commit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
       "scm/resourceState/context": [
         {
           "command": "jj.openFileResourceState",
-          "when": "scmProvider == jj && scmResourceGroup == @",
+          "when": "scmProvider == jj",
           "group": "inline"
         },
         {


### PR DESCRIPTION
It's very useful to be able to open the editable file for a previous commit. The action for opening was restricted to the current working copy for some reason, which made this annoying.  Simply showing the action on all commits in the file SCM views seems to work as expected.