### PR TITLE
Add diff syntax highlighting to jj-commit language

### DIFF
--- a/syntaxes/jj-commit.tmLanguage.json
+++ b/syntaxes/jj-commit.tmLanguage.json
@@ -3,6 +3,18 @@
     "scopeName": "text.jj-commit",
     "patterns": [
         {
+            "comment": "diff presented at the end of the commit message when using jj describe with diff template",
+            "name": "meta.embedded.diff.jj-commit",
+            "contentName": "source.diff",
+            "begin": "(?=^diff\\ \\-\\-git)",
+            "end": "\\z",
+            "patterns": [
+                {
+                    "include": "source.diff"
+                }
+            ]
+        },
+        {
             "comment": "User supplied message",
             "name": "meta.scope.message.jj-commit",
             "begin": "^(?!JJ:)",


### PR DESCRIPTION
This is useful if you have a git diff configured to show up when you run `jj describe` like so:

```
[templates]
draft_commit_description = '''
concat(
  builtin_draft_commit_description,
  "JJ:\nJJ: ignore-rest\n",
  diff.git(),
)
'''
```

```
Add diff syntax highlighting to jj-commit language

JJ: Change ID: tnuvmyvp
JJ: This commit contains the following changes:
JJ:     M syntaxes/jj-commit.tmLanguage.json
JJ: ignore-rest
diff --git a/syntaxes/jj-commit.tmLanguage.json b/syntaxes/jj-commit.tmLanguage.json
index 6a85887832..472b711703 100644
--- a/syntaxes/jj-commit.tmLanguage.json
+++ b/syntaxes/jj-commit.tmLanguage.json
@@ -3,6 +3,18 @@
     "scopeName": "text.jj-commit",
     "patterns": [
         {
+            "comment": "diff presented at the end of the commit message when using jj describe with diff template",
+            "name": "meta.embedded.diff.jj-commit",
+            "contentName": "source.diff",
+            "begin": "(?=^diff\\ \\-\\-git)",
+            "end": "\\z",
+            "patterns": [
+                {
+                    "include": "source.diff"
+                }
+            ]
+        },
+        {
             "comment": "User supplied message",
             "name": "meta.scope.message.jj-commit",
             "begin": "^(?!JJ:)",
@@ -57,4 +69,4 @@
             ]
         }
     ]
-}
\ No newline at end of file
+}

JJ: Lines starting with "JJ:" (like this one) will be removed.
```

Based off https://github.com/microsoft/vscode/blob/33094f306c8868f75bafe3f30879e14a006ef7b1/extensions/git-base/syntaxes/git-commit.tmLanguage.json#L11-L22