### PR TITLE
remove jj prefix from jjVersion

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -25,7 +25,7 @@ async function getJJVersion(jjPath: string): Promise<string> {
     .trim();
 
   if (version.startsWith("jj")) {
-    return version;
+    return version.replace(/^jj\s*/, "");
   }
 
   throw new Error(`Failed to parse jj version from ${jjPath}: ${version}`);
@@ -102,7 +102,7 @@ async function getConfigArgs(
 
   // Determine the config option and value based on jj version
   const configOption =
-    jjVersion >= "jj 0.25.0" ? "--config-file" : "--config-toml";
+    jjVersion >= "0.25.0" ? "--config-file" : "--config-toml";
 
   if (configOption === "--config-toml") {
     try {
@@ -969,7 +969,7 @@ export class JJRepository {
     const revSeparator = "jjkඞ\n";
     const fieldSeparator = "ඞjjk";
     const summarySeparator = "@?!"; // characters that are illegal in filepaths
-    const isConflictDetectionSupported = this.jjVersion >= "jj 0.26.0";
+    const isConflictDetectionSupported = this.jjVersion >= "0.26.0";
     const templateFields = [
       "change_id",
       "commit_id",
@@ -1750,7 +1750,7 @@ export class JJRepository {
     return (
       await handleJJCommand(
         this.spawnJJ(
-          ["operation", this.jjVersion >= "jj 0.33.0" ? "revert" : "undo", id],
+          ["operation", this.jjVersion >= "0.33.0" ? "revert" : "undo", id],
           {
             timeout: 5000,
             cwd: this.repositoryRoot,


### PR DESCRIPTION
This will allow us to use the `semver` package more easily to properly compare versions upstack, rather than doing lexicographical comparisons.