### PR TITLE
update templating to prevent all newlines from appearing in log entries

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -959,17 +959,18 @@ export class JJRepository {
   async showAll(revsets: string[]) {
     const revSeparator = "jjkඞ\n";
     const fieldSeparator = "ඞjjk";
-    const summarySeparator = "@?!"; // characters that are illegal in filepaths
+    const summaryFileSeparator = "j@j@k";
+    const summaryFileFieldSeparator = "@?!"; // characters that are illegal in filepaths
     const templateFields = [
       "change_id",
       "commit_id",
       "author.name()",
       "author.email()",
       'author.timestamp().local().format("%F %H:%M:%S")',
-      "description",
+      "description.escape_json()",
       "empty",
       "conflict",
-      `diff.files().map(|entry| entry.status() ++ "${summarySeparator}" ++ entry.source().path().display() ++ "${summarySeparator}" ++ entry.target().path().display() ++ "${summarySeparator}" ++ entry.target().conflict()).join("\n")`,
+      `diff.files().map(|entry| entry.status() ++ "${summaryFileFieldSeparator}" ++ entry.source().path().display() ++ "${summaryFileFieldSeparator}" ++ entry.target().path().display() ++ "${summaryFileFieldSeparator}" ++ entry.target().conflict()).join("${summaryFileSeparator}")`,
     ];
     const template =
       templateFields.join(` ++ "${fieldSeparator}" ++ `) +
@@ -1004,7 +1005,8 @@ export class JJRepository {
         revResult,
         templateFields,
         fieldSeparator,
-        summarySeparator,
+        summaryFileSeparator,
+        summaryFileFieldSeparator,
       ),
     );
   }
@@ -1015,17 +1017,18 @@ export class JJRepository {
   } {
     const revSeparator = "jjkඞ\n";
     const fieldSeparator = "ඞjjk";
-    const summarySeparator = "@?!"; // characters that are illegal in filepaths
+    const summaryFileSeparator = "j@j@k";
+    const summaryFileFieldSeparator = "@?!"; // characters that are illegal in filepaths
     const templateFields = [
       "change_id",
       "commit_id",
       "author.name()",
       "author.email()",
       'author.timestamp().local().format("%F %H:%M:%S")',
-      "description",
+      "description.escape_json()",
       "empty",
       "conflict",
-      `diff.files().map(|entry| entry.status() ++ "${summarySeparator}" ++ entry.source().path().display() ++ "${summarySeparator}" ++ entry.target().path().display() ++ "${summarySeparator}" ++ entry.target().conflict()).join("\n")`,
+      `diff.files().map(|entry| entry.status() ++ "${summaryFileFieldSeparator}" ++ entry.source().path().display() ++ "${summaryFileFieldSeparator}" ++ entry.target().path().display() ++ "${summaryFileFieldSeparator}" ++ entry.target().conflict()).join("${summaryFileSeparator}")`,
     ];
     const template =
       templateFields.join(` ++ "${fieldSeparator}" ++ `) +
@@ -1075,7 +1078,8 @@ export class JJRepository {
             revResult,
             templateFields,
             fieldSeparator,
-            summarySeparator,
+            summaryFileSeparator,
+            summaryFileFieldSeparator,
           );
           separatorIndex = buffer.indexOf(revSeparator);
         }
@@ -1099,7 +1103,8 @@ export class JJRepository {
     revResult: string,
     templateFields: string[],
     fieldSeparator: string,
-    summarySeparator: string,
+    summaryFileSeparator: string,
+    summaryFileFieldSeparator: string,
   ): Show {
     const fields = revResult.split(fieldSeparator);
     if (fields.length > templateFields.length) {
@@ -1145,8 +1150,14 @@ export class JJRepository {
         case 'author.timestamp().local().format("%F %H:%M:%S")':
           ret.change.authoredDate = value;
           break;
-        case "description":
-          ret.change.description = value;
+        case "description.escape_json()":
+          {
+            const parsed: unknown = JSON.parse(value);
+            if (typeof parsed !== "string") {
+              throw new Error("Unexpected description JSON payload.");
+            }
+            ret.change.description = parsed;
+          }
           break;
         case "empty":
           ret.change.isEmpty = value === "true";
@@ -1155,9 +1166,12 @@ export class JJRepository {
           ret.change.isConflict = value === "true";
           break;
         default: {
-          for (const line of value.split("\n").filter(Boolean)) {
-            const [status, rawSourcePath, rawTargetPath, conflict] =
-              line.split(summarySeparator);
+          for (const line of value
+            .split(summaryFileSeparator)
+            .filter(Boolean)) {
+            const [status, rawSourcePath, rawTargetPath, conflict] = line.split(
+              summaryFileFieldSeparator,
+            );
             const sourcePath = path
               .normalize(rawSourcePath)
               .replace(/\\/g, "/");


### PR DESCRIPTION
Upstack we want to drop the `--no-graph` flag so that `jj log` will output changes in graph-visualization order.

If we drop the `--no-graph` flag, then obviously the graph will be rendered. This is problematic for parsing. 

```
$ jj log -T '"start" ++ description ++ "end"'
@  starthi
│  im
│  multiple
│  lines
│  end
○  startsome single-line description here
│  end
```

Note how a multiline description will get the graph symbols interleaved into it. When our parser reads what's between "start" and "end", expecting to see the user's unedited description, it will instead the pipe symbols. In order to avoid this, we need to make sure there are no newlines whatsoever in each change's template. If we use `.escape_json()`, that will escape all the newlines in the description for us. Likewise, we need to use a different delimiter than a newline to separate between summary file fields, so that change was made too.