### PR TITLE
get parents of log entries

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -964,6 +964,8 @@ export class JJRepository {
     const templateFields = [
       "change_id",
       "commit_id",
+      'if(parents, "[" ++ parents.map(|p| stringify(p.change_id()).escape_json()).join(",") ++ "]", "[]")',
+      'if(parents, "[" ++ parents.map(|p| stringify(p.commit_id()).escape_json()).join(",") ++ "]", "[]")',
       "author.name()",
       "author.email()",
       'author.timestamp().local().format("%F %H:%M:%S")',
@@ -1043,6 +1045,8 @@ export class JJRepository {
     const templateFields = [
       "change_id",
       "commit_id",
+      'if(parents, "[" ++ parents.map(|p| stringify(p.change_id()).escape_json()).join(",") ++ "]", "[]")',
+      'if(parents, "[" ++ parents.map(|p| stringify(p.commit_id()).escape_json()).join(",") ++ "]", "[]")',
       "author.name()",
       "author.email()",
       'author.timestamp().local().format("%F %H:%M:%S")',
@@ -1131,6 +1135,13 @@ export class JJRepository {
     summaryFileSeparator: string,
     summaryFileFieldSeparator: string,
   ): Show {
+    const parseJsonStringArray = (value: string, fieldName: string) => {
+      const parsed: unknown = JSON.parse(value);
+      if (!Array.isArray(parsed)) {
+        throw new Error(`Unexpected ${fieldName} JSON payload.`);
+      }
+      return parsed.map((item) => String(item));
+    };
     const fields = revResult.split(fieldSeparator);
     if (fields.length > templateFields.length) {
       throw new Error(
@@ -1143,6 +1154,8 @@ export class JJRepository {
       change: {
         changeId: "",
         commitId: "",
+        parentChangeIds: [],
+        parentCommitIds: [],
         description: "",
         author: {
           email: "",
@@ -1166,6 +1179,20 @@ export class JJRepository {
         case "commit_id":
           ret.change.commitId = value;
           break;
+        case 'if(parents, "[" ++ parents.map(|p| stringify(p.change_id()).escape_json()).join(",") ++ "]", "[]")': {
+          ret.change.parentChangeIds = parseJsonStringArray(
+            value,
+            "parent change ids",
+          );
+          break;
+        }
+        case 'if(parents, "[" ++ parents.map(|p| stringify(p.commit_id()).escape_json()).join(",") ++ "]", "[]")': {
+          ret.change.parentCommitIds = parseJsonStringArray(
+            value,
+            "parent commit ids",
+          );
+          break;
+        }
         case "author.name()":
           ret.change.author.name = value;
           break;
@@ -2034,6 +2061,8 @@ export interface ChangeWithDetails extends Change {
     email: string;
   };
   authoredDate: string;
+  parentChangeIds: string[];
+  parentCommitIds: string[];
 }
 
 export type RepositoryStatus = {


### PR DESCRIPTION
In order to rebuild the graph shape, we depend on both the order of the changes that we get from `jj log` as well as the parent relationships. In order to track the parent relationships, we need to get that information out of `jj log`. That's what this PR is for.