### PR TITLE
Add "jj new" as an option instead of "edit"

### DIFF
--- a/package.json
+++ b/package.json
@@ -480,6 +480,17 @@
           "default": false,
           "description": "Use --ignore-working-copy for read-only commands to prevent automatic working copy snapshots. This prevents divergent changesets from passive monitoring, but modified files may not auto-update until the next manual jj command.",
           "scope": "resource"
+        },
+        "jjk.changeEditAction": {
+          "type": "string",
+          "default": "edit",
+          "enum": ["edit", "new"],
+          "enumDescriptions": [
+            "Edits the change (jj edit)",
+            "Creates an empty change on top and switches to it (jj new)"
+          ],
+          "description": "Action to perform when clicking the edit button on a change in the graph view",
+          "scope": "resource"
         }
       }
     },

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -103,6 +103,22 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
             );
           }
           break;
+        case "editChangeDirect":
+          try {
+            if (message.changeId === "zzzzzzzz") {
+              return;
+            }
+            const status = await this.repository.getStatus(true);
+            if (message.changeId === status.workingCopy.changeId) {
+              return;
+            }
+            await this.repository.editRetryImmutable(message.changeId);
+          } catch (error: unknown) {
+            vscode.window.showErrorMessage(
+              `Failed to switch to change: ${error as string}`,
+            );
+          }
+          break;
         case "selectChange":
           this.selectedNodes = new Set(message.selectedNodes);
           vscode.commands.executeCommand(

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,14 @@ export async function activate(context: vscode.ExtensionContext) {
         await checkReposFunction(affectedFolders);
       }
     }
+    if (e.affectsConfiguration("jjk.changeEditAction")) {
+      const config = vscode.workspace.getConfiguration("jjk");
+      const changeEditAction =
+        config.get<string>("changeEditAction") || "edit";
+      for (const repoSCM of workspaceSCM.repoSCMs) {
+        repoSCM.updatePlaceholderText(changeEditAction);
+      }
+    }
   });
 
   let isInitialized = false;
@@ -374,8 +382,15 @@ export async function activate(context: vscode.ExtensionContext) {
             if (!repository) {
               throw new Error("Repository not found");
             }
+            const config = vscode.workspace.getConfiguration("jjk");
+            const changeEditAction =
+              config.get<string>("changeEditAction") || "edit";
             const message = sourceControl.inputBox.value.trim() || undefined;
-            await repository.new(message);
+            if (changeEditAction === "new") {
+              await repository.commit(message);
+            } else {
+              await repository.new(message);
+            }
             sourceControl.inputBox.value = "";
           } catch (error) {
             vscode.window.showErrorMessage(

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -584,11 +584,10 @@ class RepositorySourceControlManager {
     );
     this.subscriptions.push(this.workingCopyResourceGroup);
 
-    // Set up the SourceControlInputBox
-    this.sourceControl.inputBox.placeholder =
-      "Describe new change (Ctrl+Enter)";
+    const config = vscode.workspace.getConfiguration("jjk");
+    const changeEditAction = config.get<string>("changeEditAction") || "edit";
+    this.updatePlaceholderText(changeEditAction);
 
-    // Link the acceptInputCommand to the SourceControl instance
     this.sourceControl.acceptInputCommand = {
       command: "jj.new",
       title: "Create new change",
@@ -621,6 +620,13 @@ class RepositorySourceControlManager {
       undefined,
       this.subscriptions,
     );
+  }
+
+  updatePlaceholderText(changeEditAction: string) {
+    this.sourceControl.inputBox.placeholder =
+      changeEditAction === "new"
+        ? "Describe current change (Ctrl+Enter)"
+        : "Describe new change (Ctrl+Enter)";
   }
 
   async checkForUpdates() {
@@ -1209,6 +1215,29 @@ export class JJRepository {
             cwd: this.repositoryRoot,
           },
         ),
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        const match = error.message.match(/error:\s*([\s\S]+)$/i);
+        if (match) {
+          const errorMessage = match[1];
+          throw new Error(errorMessage);
+        } else {
+          throw error;
+        }
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async commit(message?: string) {
+    try {
+      return await handleJJCommand(
+        this.spawnJJ(["commit", ...(message ? ["-m", message] : [])], {
+          timeout: 5000,
+          cwd: this.repositoryRoot,
+        }),
       );
     } catch (error) {
       if (error instanceof Error) {

--- a/src/webview/graph.css
+++ b/src/webview/graph.css
@@ -174,3 +174,28 @@ body {
 .node-circle.highlighted .diamond-path {
     opacity: 1;
 }
+
+/* Context menu styling */
+.context-menu {
+    display: none;
+    position: absolute;
+    background-color: var(--vscode-menu-background);
+    border: 1px solid var(--vscode-menu-border);
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+    min-width: 120px;
+    padding: 4px 0;
+}
+
+.context-menu-item {
+    padding: 6px 20px;
+    cursor: pointer;
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-menu-foreground);
+}
+
+.context-menu-item:hover {
+    background-color: var(--vscode-menu-selectionBackground);
+    color: var(--vscode-menu-selectionForeground);
+}

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -39,7 +39,7 @@
                         command: 'selectChange',
                         selectedNodes: []
                     });
-                    updateGraph(message.changes, message.workingCopyId, message.preserveScroll);
+                    updateGraph(message.changes, message.workingCopyId, message.changeEditAction, message.preserveScroll);
                     break;
             }
         });
@@ -327,7 +327,7 @@
             return [fromNode, toNode];
         }
 
-        function updateGraph(changes, workingCopyId, preserveScroll = false) {
+        function updateGraph(changes, workingCopyId, changeEditAction, preserveScroll = false) {
             // Save current scroll position only when preserveScroll is true
             const scrollTop = preserveScroll ?
                 (window.scrollY || document.documentElement.scrollTop) : 0;
@@ -374,7 +374,7 @@
                 const editButton = document.createElement('button');
                 editButton.className = 'edit-button';
                 editButton.innerHTML = '<i class="codicon codicon-log-in"></i>';
-                editButton.title = 'Edit this change';
+                editButton.title = changeEditAction === 'new' ? 'Create and edit a new empty change on top' : 'Edit this change';
                 editButton.onclick = async (e) => {
                     e.stopPropagation();
                     // Just send the edit command and let updateGraph handle the cleanup
@@ -384,8 +384,8 @@
                     });
                 };
 
-                // Hide edit button if this is the working copy or has ID "zzzzzzzz"
-                if (change.contextValue === workingCopyId || change.contextValue === "zzzzzzzz") {
+                // Hide edit button if this is the working copy, or root commit in edit mode
+                if (change.contextValue === workingCopyId || (changeEditAction === 'edit' && change.contextValue === "zzzzzzzz")) {
                     editButton.style.display = 'none';
                 }
                 node.appendChild(editButton);

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -7,6 +7,9 @@
 </head>
 
 <body>
+    <div id="context-menu" class="context-menu">
+        <div class="context-menu-item" data-action="edit">Edit this change</div>
+    </div>
     <div id="graph">
         <svg id="connections">
             <defs id="svg-defs"></defs>
@@ -431,6 +434,18 @@
                         selectedNodes: Array.from(selectedNodes)
                     });
                 };
+
+                node.addEventListener('contextmenu', (e) => {
+                    e.preventDefault();
+                    if (change.contextValue === "zzzzzzzz" || change.contextValue === currentWorkingCopyId) {
+                        return;
+                    }
+                    const contextMenu = document.getElementById('context-menu');
+                    contextMenu.dataset.changeId = change.contextValue;
+                    contextMenu.style.left = e.pageX + 'px';
+                    contextMenu.style.top = e.pageY + 'px';
+                    contextMenu.style.display = 'block';
+                });
             });
 
             // Wait for next frame to ensure DOM is updated
@@ -443,6 +458,22 @@
                 }
             });
         }
+
+        document.addEventListener('click', () => {
+            const contextMenu = document.getElementById('context-menu');
+            contextMenu.style.display = 'none';
+        });
+
+        document.getElementById('context-menu').addEventListener('click', (e) => {
+            const contextMenu = document.getElementById('context-menu');
+            const changeId = contextMenu.dataset.changeId;
+            if (changeId && changeId !== "zzzzzzzz") {
+                vscode.postMessage({
+                    command: 'editChangeDirect',
+                    changeId: changeId
+                });
+            }
+        });
 
         function updateCirclePositions() {
             const nodes = document.querySelectorAll('.change-node');


### PR DESCRIPTION
This change adds a new VS Code setting `jjk.changeEditAction` to configure what happens when the user clicks the edit button on a change and what the commit action does. Possible values:

* "edit" (default):
  * Clicking the edit button edits the clicked change (existing behavior)
  * Commiting runs `jj new && jj desc -m $message` (existing behavior)
* "new":
  * Clicking the edit button runs "jj new" on the change
  * Commiting runs `jj commit -m $message`

The "new" behavior is useful for the squash workflow:
https://steveklabnik.github.io/jujutsu-tutorial/real-world-workflows/the-squash-workflow.html

It saves a click compared to the current way, which is to click on a change followed by a click on "+". The new commit behavior matches the workflow.

Sometimes it can still be desirable to edit a change in the "new" mode. For this reason, this change adds an "Edit this change" command to the right-click context menu which was otherwise unused. The context menu can also be useful for other commands in the future.