### PR TITLE
Add source control graph hover details

### DIFF
--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -5,14 +5,15 @@ import path from "path";
 
 type Message = {
   command: string;
-  changeId: string;
-  selectedNodes: string[];
+  changeId?: string;
+  selectedNodes?: string[];
 };
 
 export class ChangeNode {
   // The parser keeps row metadata decomposed so the webview can lay out jj-style columns without
   // having to reverse-engineer a preformatted label string.
   description: string;
+  fullDescription: string;
   tooltip: string;
   contextValue: string;
   parentChangeIds?: string[];
@@ -30,6 +31,7 @@ export class ChangeNode {
   symbolColumn: number;
   constructor(
     description: string,
+    fullDescription: string,
     tooltip: string,
     contextValue: string,
     changeId: string,
@@ -47,6 +49,7 @@ export class ChangeNode {
     branchType?: string,
   ) {
     this.description = description;
+    this.fullDescription = fullDescription;
     this.tooltip = tooltip;
     this.contextValue = contextValue;
     this.changeId = changeId;
@@ -118,6 +121,9 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
     webviewView.webview.onDidReceiveMessage(async (message: Message) => {
       switch (message.command) {
         case "editChange":
+          if (!message.changeId) {
+            break;
+          }
           try {
             await this.repository.editRetryImmutable(message.changeId);
           } catch (error: unknown) {
@@ -127,12 +133,34 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
           }
           break;
         case "selectChange":
-          this.selectedNodes = new Set(message.selectedNodes);
+          this.selectedNodes = new Set(message.selectedNodes ?? []);
           vscode.commands.executeCommand(
             "setContext",
             "jjGraphView.nodesSelected",
-            message.selectedNodes.length,
+            message.selectedNodes?.length ?? 0,
           );
+          break;
+        case "requestChangeDetails":
+          if (!message.changeId) {
+            break;
+          }
+          try {
+            // Keep the list rows cheap to render by fetching the full description only when the
+            // user asks for hover details on a specific change.
+            const showResult = await this.repository.show(message.changeId);
+            this.panel?.webview.postMessage({
+              command: "changeDetails",
+              changeId: message.changeId,
+              fullDescription:
+                showResult.change.description || "(no description set)",
+            });
+          } catch {
+            this.panel?.webview.postMessage({
+              command: "changeDetails",
+              changeId: message.changeId,
+              fullDescription: undefined,
+            });
+          }
           break;
       }
     });
@@ -282,6 +310,7 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
       return (
         nodeA.tooltip === nodeB.tooltip &&
         nodeA.description === nodeB.description &&
+        nodeA.fullDescription === nodeB.fullDescription &&
         nodeA.contextValue === nodeB.contextValue &&
         nodeA.changeId === nodeB.changeId &&
         nodeA.commitId === nodeB.commitId &&
@@ -316,6 +345,24 @@ export function parseJJLog(output: string): ChangeNode[] {
   const stripGraphPrefix = (line: string) =>
     line.replace(/^[^a-zA-Z0-9(~]+/, "").trim();
 
+  const isGraphContinuationLine = (line: string) =>
+    /^[^a-zA-Z0-9~]*[│├╯╰╮╭─ ]/.test(line) || /^[^a-zA-Z0-9~]*$/.test(line);
+
+  const isEntryStartLine = (line: string) => {
+    const trimmedLine = line.trimEnd();
+    if (!trimmedLine) {
+      return false;
+    }
+
+    const strippedLine = stripGraphPrefix(trimmedLine);
+    return (
+      rootPattern.test(trimmedLine) ||
+      strippedLine === "~" ||
+      strippedLine === "~  (elided revisions)" ||
+      timestampPattern.test(trimmedLine)
+    );
+  };
+
   const getSymbolColumn = (line: string, branchType?: string) =>
     branchType ? Math.max(0, line.indexOf(branchType)) : 0;
 
@@ -338,6 +385,7 @@ export function parseJJLog(output: string): ChangeNode[] {
       changeNodes.push(
         new ChangeNode(
           "Older revisions hidden",
+          "Older revisions hidden",
           "Older revisions are hidden by the current jj log limit.",
           "",
           "",
@@ -358,25 +406,38 @@ export function parseJJLog(output: string): ChangeNode[] {
       continue;
     }
 
-    // The compact row layout only reserves one summary line below the metadata line.
-    let descriptionLine = "";
-    const nextLine = lines[i + 1]?.trimEnd() ?? "";
-    if (nextLine && !timestampPattern.test(nextLine)) {
-      descriptionLine = stripGraphPrefix(nextLine);
+    // The compact row layout only reserves one visible summary line, but the hover needs the full
+    // body block. Keep both representations so the webview does not have to widen the list rows.
+    const descriptionLines: string[] = [];
+    while (i + 1 < lines.length) {
+      const nextLine = lines[i + 1] ?? "";
+      if (isEntryStartLine(nextLine) || !isGraphContinuationLine(nextLine)) {
+        break;
+      }
+
+      descriptionLines.push(stripGraphPrefix(nextLine.trimEnd()));
       i++;
     }
 
-    const isEmpty = descriptionLine.includes("(empty)");
-    const isConflict = descriptionLine.includes("(conflict)");
-    const cleanedDescription = descriptionLine
+    const summarySource =
+      descriptionLines.find((line) => line.trim().length > 0) ?? "";
+    const isEmpty = summarySource.includes("(empty)");
+    const isConflict = summarySource.includes("(conflict)");
+    const cleanedDescription = summarySource
       .replace(/\(empty\)\s*/g, "")
       .replace(/\(conflict\)\s*/g, "")
       .trim();
+    const cleanedDescriptionLines = descriptionLines.map((line) =>
+      line
+        .replace(/\(empty\)\s*/g, "")
+        .replace(/\(conflict\)\s*/g, ""),
+    );
+    const fullDescription = cleanedDescriptionLines.join("\n").trim();
     const hasDescription =
-      cleanedDescription.length > 0 &&
-      cleanedDescription !== "(no description set)";
-    const description = hasDescription
-      ? cleanedDescription
+      fullDescription.length > 0 && fullDescription !== "(no description set)";
+    const description = hasDescription ? cleanedDescription : "(no description set)";
+    const fullDescriptionText = hasDescription
+      ? fullDescription
       : "(no description set)";
 
     const rootMatch = headerLine.match(rootPattern);
@@ -387,6 +448,7 @@ export function parseJJLog(output: string): ChangeNode[] {
 
       changeNodes.push(
         new ChangeNode(
+          normalizedDescription,
           normalizedDescription,
           `Change: ${changeId}\nCommit: ${commitId}\nRef: ${refName}${
             isEmpty ? "\nStatus: empty" : ""
@@ -450,12 +512,15 @@ export function parseJJLog(output: string): ChangeNode[] {
       refName ? `Ref: ${refName}` : "",
       isEmpty ? "Status: empty" : "",
       isConflict ? "Status: conflict" : "",
-      hasDescription ? `Description: ${description}` : "Description: (no description set)",
+      hasDescription
+        ? `Description: ${fullDescriptionText}`
+        : "Description: (no description set)",
     ].filter(Boolean);
 
     changeNodes.push(
       new ChangeNode(
         description,
+        fullDescriptionText,
         tooltipLines.join("\n"),
         changeId,
         changeId,

--- a/src/test/graphWebview.test.ts
+++ b/src/test/graphWebview.test.ts
@@ -137,4 +137,22 @@ suite("parseJJLog", () => {
     assert.strictEqual(node.hasDescription, false);
     assert.strictEqual(node.description, "No description set");
   });
+
+  test("preserves the full multi-line description for hover details", () => {
+    const output = `@  nxxvmutx joshka@users.noreply.github.com 2026-03-26 12:58:52 eaf68a4c
+│  Add graph popup
+│
+│  Keep the row compact.
+│  Show the body only in the hover.
+`;
+
+    const [node] = parseJJLog(output);
+
+    assert.ok(node);
+    assert.strictEqual(node.description, "Add graph popup");
+    assert.strictEqual(
+      node.fullDescription,
+      "Add graph popup\n\nKeep the row compact.\nShow the body only in the hover.",
+    );
+  });
 });

--- a/src/webview/graph.css
+++ b/src/webview/graph.css
@@ -13,6 +13,117 @@ body {
   padding: 4px 0 8px 8px;
 }
 
+#hover-card {
+  position: absolute;
+  z-index: 20;
+  max-width: min(520px, calc(100vw - 32px));
+  min-width: min(360px, calc(100vw - 48px));
+  padding: 10px 12px;
+  border: 1px solid
+    var(--vscode-editorHoverWidget-border, var(--vscode-widget-border));
+  border-radius: 5px;
+  background: var(
+    --vscode-editorHoverWidget-background,
+    var(--vscode-sideBar-background)
+  );
+  box-shadow: var(--vscode-widget-shadow, 0 8px 24px rgba(0, 0, 0, 0.36));
+  color: var(--vscode-editorHoverWidget-foreground, var(--vscode-foreground));
+  pointer-events: auto;
+  user-select: text;
+}
+
+.hover-field-grid {
+  display: grid;
+  gap: 4px;
+}
+
+.hover-field-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
+}
+
+.hover-field-key {
+  color: var(--vscode-descriptionForeground);
+  white-space: nowrap;
+}
+
+.hover-field-value {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.hover-field-value .meta-pill,
+.hover-field-value .segmented-id {
+  flex: 0 0 auto;
+}
+
+.hover-field-value .meta-pill {
+  max-width: none;
+}
+
+.hover-field-value .meta-pill-label {
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.hover-author {
+  font-size: 1em;
+  font-weight: 600;
+  color: var(--vscode-terminal-ansiYellow);
+}
+
+.hover-timestamp {
+  color: var(--vscode-charts-blue);
+  white-space: nowrap;
+}
+
+.hover-description {
+  line-height: 1.35;
+  font-size: 1em;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid
+    var(--vscode-editorHoverWidget-border, rgba(255, 255, 255, 0.08));
+}
+
+.hover-description.placeholder {
+  color: var(--vscode-terminal-ansiGreen);
+}
+
+.hover-email {
+  color: var(--vscode-descriptionForeground);
+  word-break: break-all;
+  user-select: text;
+}
+
+.hover-copy-button {
+  opacity: 0;
+  background: none;
+  border: none;
+  color: var(--vscode-icon-foreground);
+  cursor: pointer;
+  padding: 0;
+  margin-left: 2px;
+  line-height: 1;
+  border-radius: 3px;
+}
+
+.hover-field-row:hover .hover-copy-button,
+.hover-copy-button:focus-visible {
+  opacity: 1;
+}
+
+.hover-copy-button:hover {
+  color: var(--vscode-textLink-foreground);
+}
+
 #connections {
   position: absolute;
   top: 0;
@@ -61,7 +172,7 @@ body {
 .change-node.selected {
   background-color: var(--vscode-list-activeSelectionBackground);
   color: var(--vscode-list-activeSelectionForeground);
-  border-color: var(--vscode-focusBorder);
+  border-color: transparent;
 }
 
 /* Dimming and highlighting effects */
@@ -164,22 +275,15 @@ body {
   line-height: 1.25;
   border: 1px solid transparent;
   white-space: nowrap;
-  max-width: 18ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
 }
 
 .meta-pill-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .meta-pill.ref-name {
-  flex: 0 1 auto;
-  max-width: min(24ch, 38cqw);
+  flex: 0 0 auto;
 }
 
 .meta-pill.bookmark-ref {

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -19,14 +19,21 @@
       const vscode = acquireVsCodeApi();
       let selectedNodes = new Set();
       let currentWorkingCopyId;
+      let visibleChangeIds = [];
+      let visibleCommitIds = [];
+      const changeDetailsCache = new Map();
       const graphLaneStep = 10;
       const graphLanePadding = 6;
       const hoverCard = document.getElementById("hover-card");
+      let hoveredNode = null;
+      let hoverHideTimer = null;
+      let hoverShowTimer = null;
 
       window.addEventListener("message", (event) => {
         const message = event.data;
         switch (message.command) {
           case "updateGraph":
+            changeDetailsCache.clear();
             selectedNodes.clear();
             document.querySelectorAll(".change-node").forEach((n) => {
               n.classList.remove("selected", "highlighted", "dimmed");
@@ -51,6 +58,24 @@
               message.workingCopyId,
               message.preserveScroll,
             );
+            break;
+          case "changeDetails":
+            if (message.changeId) {
+              changeDetailsCache.set(message.changeId, message.fullDescription);
+              if (
+                hoveredNode &&
+                hoveredNode.dataset.changeId === message.changeId &&
+                !hoverCard.hidden
+              ) {
+                const hoveredChange = JSON.parse(
+                  hoveredNode.dataset.changePayload || "{}",
+                );
+                hoveredChange.fullDescription =
+                  message.fullDescription || hoveredChange.fullDescription;
+                hoveredNode.dataset.changePayload = JSON.stringify(hoveredChange);
+                renderHoverCard(hoveredChange, hoveredNode);
+              }
+            }
             break;
         }
       });
@@ -205,17 +230,54 @@
         return pill;
       }
 
-      function isSpecialRefName(refName) {
-        return /^(?:[a-z_][a-z0-9_-]*)\(\)$/i.test(refName);
+      function buildCopyButton(value, label) {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "hover-copy-button";
+        button.title = `Copy ${label}`;
+        button.setAttribute("aria-label", `Copy ${label}`);
+        button.innerHTML = '<i class="codicon codicon-copy"></i>';
+        button.addEventListener("click", async (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          try {
+            await navigator.clipboard.writeText(value);
+          } catch {
+            const selection = window.getSelection();
+            const range = document.createRange();
+            const temp = document.createElement("span");
+            temp.textContent = value;
+            hoverCard.appendChild(temp);
+            range.selectNodeContents(temp);
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+            document.execCommand("copy");
+            selection?.removeAllRanges();
+            temp.remove();
+          }
+        });
+        return button;
       }
 
-      function getDisplayRefName(refName) {
-        if (!refName || isSpecialRefName(refName)) {
-          return refName;
-        }
+      function appendHoverField(grid, label, valueBuilder) {
+        const row = document.createElement("div");
+        row.className = "hover-field-row";
 
-        const parts = refName.split("/");
-        return parts[parts.length - 1] || refName;
+        const key = document.createElement("span");
+        key.className = "hover-field-key";
+        key.textContent = `${label}:`;
+        row.appendChild(key);
+
+        const value = document.createElement("div");
+        value.className = "hover-field-value";
+        valueBuilder(value);
+        row.appendChild(value);
+
+        grid.appendChild(row);
+      }
+
+      function isSpecialRefName(refName) {
+        return /^(?:[a-z_][a-z0-9_-]*)\(\)$/i.test(refName);
       }
 
       function getShortDate(timestamp) {
@@ -233,101 +295,179 @@
       }
 
       function clearHoverCard() {
+        if (hoverShowTimer) {
+          clearTimeout(hoverShowTimer);
+          hoverShowTimer = null;
+        }
+        if (hoverHideTimer) {
+          clearTimeout(hoverHideTimer);
+          hoverHideTimer = null;
+        }
+        if (hoveredNode) {
+          highlightConnectedNodes(hoveredNode, false);
+        }
         hoverCard.hidden = true;
         hoverCard.innerHTML = "";
+        hoveredNode = null;
+      }
+
+      function scheduleHideHoverCard() {
+        if (hoverHideTimer) {
+          clearTimeout(hoverHideTimer);
+        }
+        hoverHideTimer = setTimeout(() => {
+          clearHoverCard();
+        }, 80);
+      }
+
+      function cancelHideHoverCard() {
+        if (hoverHideTimer) {
+          clearTimeout(hoverHideTimer);
+          hoverHideTimer = null;
+        }
+      }
+
+      function scheduleShowHoverCard(change, node) {
+        if (hoverShowTimer) {
+          clearTimeout(hoverShowTimer);
+        }
+        hoverShowTimer = setTimeout(() => {
+          hoverShowTimer = null;
+          renderHoverCard(change, node);
+        }, 300);
       }
 
       function positionHoverCard(node) {
         const nodeRect = node.getBoundingClientRect();
         const graphRect = document.getElementById("graph").getBoundingClientRect();
-        const maxWidth = 420;
-        const left = Math.min(
-          nodeRect.left - graphRect.left + 16,
-          window.innerWidth - graphRect.left - maxWidth - 16,
+        const cardWidth = hoverCard.offsetWidth || 0;
+        const cardHeight = hoverCard.offsetHeight || 0;
+        const preferredRight = nodeRect.right - graphRect.left + 12;
+        const preferredLeft = nodeRect.left - graphRect.left - cardWidth - 12;
+        const maxLeft = graphRect.width - cardWidth - 8;
+        const left =
+          preferredRight + cardWidth <= graphRect.width - 8
+            ? preferredRight
+            : Math.max(8, Math.min(preferredLeft, maxLeft));
+        const preferredTop = nodeRect.top - graphRect.top - 4;
+        const maxTop = graphRect.height - cardHeight - 8;
+        const top = Math.max(
+          8,
+          Math.min(preferredTop, Math.max(8, maxTop)),
         );
-        const preferredTop = nodeRect.top - graphRect.top - 8;
-        hoverCard.style.left = `${Math.max(8, left)}px`;
-        hoverCard.style.top = `${Math.max(8, preferredTop)}px`;
+        hoverCard.style.left = `${left}px`;
+        hoverCard.style.top = `${top}px`;
       }
 
       function renderHoverCard(change, node) {
         hoverCard.innerHTML = "";
 
-        const header = document.createElement("div");
-        header.className = "hover-header";
+        const headerFields = document.createElement("div");
+        headerFields.className = "hover-field-grid";
 
-        const author = document.createElement("div");
-        author.className = "hover-author";
-        author.textContent = change.authorDisplay || change.author || "Unknown author";
-        header.appendChild(author);
-
-        if (change.timestamp) {
-          const timestamp = document.createElement("div");
-          timestamp.className = "hover-timestamp";
-          timestamp.textContent = change.timestamp;
-          header.appendChild(timestamp);
+        if (change.commitId) {
+          appendHoverField(headerFields, "Commit ID", (value) => {
+            value.append(
+              buildSegmentedId(
+                change.commitId,
+                "commit-id",
+                getUniquePrefixLength(change.commitId, visibleCommitIds, 1),
+              ),
+            );
+            value.append(buildCopyButton(change.commitId, "commit ID"));
+          });
         }
 
-        hoverCard.appendChild(header);
+        if (change.changeId) {
+          appendHoverField(headerFields, "Change ID", (value) => {
+            value.append(
+              buildSegmentedId(
+                change.changeId,
+                "change-id",
+                getUniquePrefixLength(change.changeId, visibleChangeIds, 1),
+              ),
+            );
+            value.append(buildCopyButton(change.changeId, "change ID"));
+          });
+        }
 
-        if (change.description) {
+        if (change.authorDisplay || change.author) {
+          appendHoverField(headerFields, "Author", (value) => {
+            const author = document.createElement("span");
+            author.className = "hover-author";
+            author.textContent = change.authorDisplay || change.author;
+            value.append(author);
+
+            if (change.author) {
+              const email = document.createElement("span");
+              email.className = "hover-email";
+              email.textContent = `<${change.author}>`;
+              value.append(email);
+            }
+          });
+        }
+
+        if (change.timestamp) {
+          appendHoverField(headerFields, "Timestamp", (value) => {
+            const timestamp = document.createElement("span");
+            timestamp.className = "hover-timestamp";
+            timestamp.textContent = change.timestamp;
+            value.append(timestamp);
+          });
+        }
+
+        if (change.refName) {
+          appendHoverField(headerFields, "Ref", (value) => {
+            value.append(
+              buildMetaPill(
+                change.refName,
+                `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
+              ),
+            );
+          });
+        }
+
+        if (change.isEmpty || change.isConflict) {
+          appendHoverField(headerFields, "Status", (value) => {
+            if (change.isEmpty) {
+              value.append(buildMetaPill("empty", "status-pill empty"));
+            }
+            if (change.isConflict) {
+              value.append(buildMetaPill("conflict", "status-pill conflict"));
+            }
+          });
+        }
+
+        hoverCard.appendChild(headerFields);
+
+        // Reuse any fetched detail data so moving back onto the same node does not re-request
+        // `jj show`, but still fall back to the compact row text before the detail round-trip
+        // completes.
+        const cachedDescription = changeDetailsCache.get(change.contextValue);
+        const hoverDescription =
+          cachedDescription || change.fullDescription || change.description;
+        if (hoverDescription) {
           const description = document.createElement("div");
           description.className = `hover-description${change.hasDescription ? "" : " placeholder"}`;
-          description.textContent = change.description;
+          description.textContent = hoverDescription;
           hoverCard.appendChild(description);
         }
 
-        const statusRow = document.createElement("div");
-        statusRow.className = "hover-status-row";
-        if (change.refName) {
-          const refPill = buildMetaPill(
-            change.refName,
-            `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
-          );
-          statusRow.appendChild(refPill);
-        }
-        if (change.isEmpty) {
-          statusRow.appendChild(buildMetaPill("empty", "status-pill empty"));
-        }
-        if (change.isConflict) {
-          statusRow.appendChild(buildMetaPill("conflict", "status-pill conflict"));
-        }
-        if (statusRow.childElementCount > 0) {
-          hoverCard.appendChild(statusRow);
-        }
-
-        const metaTable = document.createElement("div");
-        metaTable.className = "hover-meta-table";
-
-        const addMetaRow = (label, value, className = "") => {
-          if (!value) {
-            return;
-          }
-          const row = document.createElement("div");
-          row.className = "hover-meta-row";
-
-          const key = document.createElement("span");
-          key.className = "hover-meta-key";
-          key.textContent = label;
-          row.appendChild(key);
-
-          const val = document.createElement("span");
-          val.className = `hover-meta-value ${className}`.trim();
-          val.textContent = value;
-          row.appendChild(val);
-          metaTable.appendChild(row);
-        };
-
-        addMetaRow("Change", change.changeId, "change-id");
-        addMetaRow("Commit", change.commitId, "commit-id");
-        addMetaRow("Email", change.author, "hover-email");
-
-        if (metaTable.childElementCount > 0) {
-          hoverCard.appendChild(metaTable);
-        }
-
         hoverCard.hidden = false;
+        hoveredNode = node;
         positionHoverCard(node);
+
+        if (
+          change.contextValue &&
+          !changeDetailsCache.has(change.contextValue)
+        ) {
+          // Hover details are fetched lazily because they include the full description body, which
+          // is intentionally omitted from the compact graph log template.
+          vscode.postMessage({
+            command: "requestChangeDetails",
+            changeId: change.contextValue,
+          });
+        }
       }
 
       function updateConnections() {
@@ -584,6 +724,8 @@
         const commitIds = changes
           .filter((candidate) => !candidate.isElided && candidate.commitId)
           .map((candidate) => candidate.commitId);
+        visibleChangeIds = changeIds;
+        visibleCommitIds = commitIds;
 
         changes.forEach((change) => {
           if (change.isElided) {
@@ -601,6 +743,7 @@
           node.dataset.parentIds = JSON.stringify(change.parentChangeIds || []);
           node.dataset.branchType = change.branchType;
           node.dataset.symbolColumn = String(change.symbolColumn || 0);
+          node.dataset.changePayload = JSON.stringify(change);
 
           // Create text content container
           const textContent = document.createElement("div");
@@ -630,7 +773,7 @@
 
           if (change.refName) {
             const refPill = buildMetaPill(
-              getDisplayRefName(change.refName),
+              change.refName,
               `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
             );
             refPill.title = change.refName;
@@ -724,13 +867,13 @@
 
           // Add hover handlers
           node.addEventListener("mouseenter", () => {
+            cancelHideHoverCard();
             highlightConnectedNodes(node, true);
-            renderHoverCard(change, node);
+            scheduleShowHoverCard(change, node);
           });
 
           node.addEventListener("mouseleave", () => {
-            highlightConnectedNodes(node, false);
-            clearHoverCard();
+            scheduleHideHoverCard();
           });
 
           node.addEventListener("mousemove", () => {
@@ -810,6 +953,7 @@
       // Update the resize handler
       let resizeTimeout;
       window.addEventListener("resize", () => {
+        clearHoverCard();
         clearTimeout(resizeTimeout);
         resizeTimeout = setTimeout(() => {
           requestAnimationFrame(() => {
@@ -817,6 +961,18 @@
             updateCirclePositions();
           });
         }, 2);
+      });
+
+      window.addEventListener("scroll", () => {
+        clearHoverCard();
+      });
+
+      hoverCard.addEventListener("mouseenter", () => {
+        cancelHideHoverCard();
+      });
+
+      hoverCard.addEventListener("mouseleave", () => {
+        scheduleHideHoverCard();
       });
 
       // Signal that the webview is ready


### PR DESCRIPTION
## Related PRs

- #226: Match source control graph rows to jj log
- #227: Add source control graph hover details
- #228: Polish source control graph hover interactions

## Review Note

This PR is intentionally opened against `main` because I do not have permission to push stacked base
branches to `keanemind/jjk`.

It depends on the row/layout changes in #226, so GitHub will show overlap from that earlier PR.
For review, start with #226 and then focus on the additional commits in this PR.

## Problem

After the row layout matches `jj log` more closely, there is still no good way to inspect a full
change from the graph itself. The compact rows only have room for the summary line, and graph
inspection still requires leaving the graph for richer metadata.

## Mental Model

This PR adds a persistent graph hover that acts as the details surface for a compact row:

- hover data is fetched on demand from `repository.show(...)`
- the hover shows field/value metadata for the current change
- the hover preserves the full multi-line commit message body instead of collapsing it to one line
- the hover keeps the compact row unchanged, so the list view stays dense

## Non-Goals

This PR does not try to make the graph hover fully native to the VS Code workbench. The graph still
runs inside a webview.

## Tradeoffs

Because the graph is a webview, the hover has to be implemented inside the webview DOM rather than
through VS Code's native hover service. This slice focuses on getting the data model and a stable
inspection UI in place before adding more interaction polish.

## Architecture Impact

- `src/graphWebview.ts`
  - exposes full description data for hover use
  - fetches detailed change information on demand through `repository.show(...)`
  - returns structured hover detail payloads to the webview
- `src/webview/graph.html`
  - adds a persistent side hover with field/value metadata and full commit body
- `src/webview/graph.css`
  - styles the hover card separately from the compact row presentation
- `src/test/graphWebview.test.ts`
  - adds regression coverage for preserving multi-line descriptions in hover data

## Observability

No new logging or telemetry.

## Tests

- `npm run compile`
- parser coverage in `src/test/graphWebview.test.ts`

## Documentation Deltas

No public docs changed in this slice.

## Issue Coverage

Partially addresses #149.

