### PR TITLE
Polish source control graph hover interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Here's what you can do so far:
   ![restore](images/restore.png)
 - Browse and navigate revision history  
   <img src="images/edit.gif" width="50%" alt="revision history">
+- Inspect the Source Control Graph with commit metadata, full commit
+  messages, change stats, and quick hover actions for editing or
+  creating a follow-up change
 - Create merge changes  
   <img src="images/merge.gif" width="50%" alt="revision history">
 

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -132,6 +132,18 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
             );
           }
           break;
+        case "newChangeFrom":
+          if (!message.changeId) {
+            break;
+          }
+          try {
+            await this.repository.new(undefined, [message.changeId]);
+          } catch (error: unknown) {
+            vscode.window.showErrorMessage(
+              `Failed to create change${error instanceof Error ? `: ${error.message}` : ""}`,
+            );
+          }
+          break;
         case "selectChange":
           this.selectedNodes = new Set(message.selectedNodes ?? []);
           vscode.commands.executeCommand(
@@ -148,17 +160,33 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
             // Keep the list rows cheap to render by fetching the full description only when the
             // user asks for hover details on a specific change.
             const showResult = await this.repository.show(message.changeId);
+            const stats = {
+              total: showResult.fileStatuses.length,
+              added: showResult.fileStatuses.filter((file) => file.type === "A")
+                .length,
+              modified: showResult.fileStatuses.filter((file) => file.type === "M")
+                .length,
+              removed: showResult.fileStatuses.filter((file) => file.type === "D")
+                .length,
+              renamed: showResult.fileStatuses.filter((file) => file.type === "R")
+                .length,
+              copied: showResult.fileStatuses.filter((file) => file.type === "C")
+                .length,
+            };
             this.panel?.webview.postMessage({
               command: "changeDetails",
               changeId: message.changeId,
-              fullDescription:
-                showResult.change.description || "(no description set)",
+              details: {
+                fullDescription:
+                  showResult.change.description || "(no description set)",
+                stats,
+              },
             });
           } catch {
             this.panel?.webview.postMessage({
               command: "changeDetails",
               changeId: message.changeId,
-              fullDescription: undefined,
+              details: undefined,
             });
           }
           break;

--- a/src/webview/graph.css
+++ b/src/webview/graph.css
@@ -51,7 +51,7 @@ body {
 
 .hover-field-value {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 6px;
   min-width: 0;
   flex-wrap: wrap;
@@ -97,30 +97,64 @@ body {
   color: var(--vscode-terminal-ansiGreen);
 }
 
+.hover-stats {
+  margin-top: 10px;
+  color: var(--vscode-descriptionForeground);
+}
+
 .hover-email {
   color: var(--vscode-descriptionForeground);
   word-break: break-all;
   user-select: text;
 }
 
+.hover-footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
 .hover-copy-button {
-  opacity: 0;
   background: none;
   border: none;
   color: var(--vscode-icon-foreground);
   cursor: pointer;
-  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px;
   margin-left: 2px;
   line-height: 1;
   border-radius: 3px;
-}
-
-.hover-field-row:hover .hover-copy-button,
-.hover-copy-button:focus-visible {
-  opacity: 1;
+  flex: 0 0 auto;
 }
 
 .hover-copy-button:hover {
+  color: var(--vscode-textLink-foreground);
+}
+
+.hover-action-button {
+  background: none;
+  border: none;
+  color: var(--vscode-icon-foreground);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px;
+  margin-left: 2px;
+  line-height: 1;
+  border-radius: 3px;
+  flex: 0 0 auto;
+}
+
+.hover-action-button.icon-only {
+  min-width: 16px;
+}
+
+.hover-action-button:hover {
   color: var(--vscode-textLink-foreground);
 }
 
@@ -178,36 +212,52 @@ body {
 /* Dimming and highlighting effects */
 .node-circle.dimmed circle,
 .node-circle.dimmed .heart-path {
-  opacity: 0.1;
+  opacity: 0.45;
 }
 
 .node-circle.highlighted circle,
 .node-circle.highlighted .heart-path {
-  opacity: 1;
+  opacity: 0.95;
 }
 
 .connection-line.dimmed {
-  opacity: 0.1;
+  opacity: 0.4;
 }
 
 .connection-line.highlighted {
-  opacity: 1;
+  opacity: 0.95;
 }
 
 /* Child connection styling */
 .connection-line.highlighted.child-connection {
-  stroke: #4caf50;
+  stroke: color-mix(
+    in srgb,
+    var(--vscode-charts-blue) 82%,
+    var(--vscode-terminal-ansiGreen) 18%
+  );
 }
 
 /* Regular child node styling */
 .node-circle.child-node circle {
-  fill: #4caf50;
-  stroke: #4caf50;
+  fill: color-mix(
+    in srgb,
+    var(--vscode-charts-blue) 82%,
+    var(--vscode-terminal-ansiGreen) 18%
+  );
+  stroke: color-mix(
+    in srgb,
+    var(--vscode-charts-blue) 82%,
+    var(--vscode-terminal-ansiGreen) 18%
+  );
 }
 
 /* Diamond-specific child node styling */
 .node-circle.child-node .diamond-path {
-  fill: #4caf50;
+  fill: color-mix(
+    in srgb,
+    var(--vscode-charts-blue) 82%,
+    var(--vscode-terminal-ansiGreen) 18%
+  );
 }
 
 /* Text content styling */
@@ -289,8 +339,6 @@ body {
 .meta-pill.bookmark-ref {
   color: #b180d7;
   background: color-mix(in srgb, #b180d7 14%, transparent);
-  padding-left: 0;
-  padding-right: 0;
 }
 
 .meta-pill.special-ref {
@@ -398,39 +446,6 @@ body {
   }
 }
 
-/* Edit button styling */
-.edit-button {
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  right: 6px;
-  transform: translateY(-50%);
-  background: none;
-  border: none;
-  color: var(--vscode-button-foreground);
-  cursor: pointer;
-  padding: 2px 6px;
-  font-size: 0.9em;
-  border-radius: 3px;
-  z-index: 2;
-}
-
-.change-node:hover .edit-button {
-  opacity: 1;
-}
-
-.edit-button:hover {
-  background-color: var(--vscode-button-secondaryHoverBackground);
-}
-
-.edit-button .codicon {
-  color: var(--vscode-icon-foreground);
-}
-
-.edit-button:hover .codicon {
-  color: var(--vscode-button-secondaryForeground);
-}
-
 /* Node circle styling */
 .node-circle {
   min-width: 12px;
@@ -472,9 +487,9 @@ body {
 
 /* Add dimming effects for diamond paths */
 .node-circle.dimmed .diamond-path {
-  opacity: 0.1;
+  opacity: 0.45;
 }
 
 .node-circle.highlighted .diamond-path {
-  opacity: 1;
+  opacity: 0.95;
 }

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -28,6 +28,7 @@
       let hoveredNode = null;
       let hoverHideTimer = null;
       let hoverShowTimer = null;
+      const hoverShowDelayMs = 700;
 
       window.addEventListener("message", (event) => {
         const message = event.data;
@@ -61,7 +62,7 @@
             break;
           case "changeDetails":
             if (message.changeId) {
-              changeDetailsCache.set(message.changeId, message.fullDescription);
+              changeDetailsCache.set(message.changeId, message.details);
               if (
                 hoveredNode &&
                 hoveredNode.dataset.changeId === message.changeId &&
@@ -70,8 +71,9 @@
                 const hoveredChange = JSON.parse(
                   hoveredNode.dataset.changePayload || "{}",
                 );
-                hoveredChange.fullDescription =
-                  message.fullDescription || hoveredChange.fullDescription;
+                if (message.details?.fullDescription) {
+                  hoveredChange.fullDescription = message.details.fullDescription;
+                }
                 hoveredNode.dataset.changePayload = JSON.stringify(hoveredChange);
                 renderHoverCard(hoveredChange, hoveredNode);
               }
@@ -259,6 +261,26 @@
         return button;
       }
 
+      function buildHoverActionButton(label, title, onClick, icon) {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "hover-action-button";
+        button.title = title;
+        button.setAttribute("aria-label", label);
+        if (icon) {
+          button.classList.add("icon-only");
+          button.innerHTML = `<i class="codicon ${icon}"></i>`;
+        } else {
+          button.textContent = label;
+        }
+        button.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onClick();
+        });
+        return button;
+      }
+
       function appendHoverField(grid, label, valueBuilder) {
         const row = document.createElement("div");
         row.className = "hover-field-row";
@@ -274,6 +296,30 @@
         row.appendChild(value);
 
         grid.appendChild(row);
+      }
+
+      function formatChangeStats(stats) {
+        if (!stats || !stats.total) {
+          return "";
+        }
+
+        const parts = [`${stats.total} file${stats.total === 1 ? "" : "s"} changed`];
+        if (stats.modified) {
+          parts.push(`${stats.modified} modified`);
+        }
+        if (stats.added) {
+          parts.push(`${stats.added} added`);
+        }
+        if (stats.removed) {
+          parts.push(`${stats.removed} removed`);
+        }
+        if (stats.renamed) {
+          parts.push(`${stats.renamed} renamed`);
+        }
+        if (stats.copied) {
+          parts.push(`${stats.copied} copied`);
+        }
+        return parts.join(" • ");
       }
 
       function isSpecialRefName(refName) {
@@ -331,26 +377,35 @@
         if (hoverShowTimer) {
           clearTimeout(hoverShowTimer);
         }
+        // The graph sits in a narrow sidebar, so wait long enough that pointer travel across
+        // adjacent rows does not constantly trigger accidental hover cards.
         hoverShowTimer = setTimeout(() => {
           hoverShowTimer = null;
           renderHoverCard(change, node);
-        }, 300);
+        }, hoverShowDelayMs);
       }
 
       function positionHoverCard(node) {
         const nodeRect = node.getBoundingClientRect();
         const graphRect = document.getElementById("graph").getBoundingClientRect();
+        const textContent =
+          node.querySelector(".text-content") || node;
+        const textRect = textContent.getBoundingClientRect();
         const cardWidth = hoverCard.offsetWidth || 0;
         const cardHeight = hoverCard.offsetHeight || 0;
-        const preferredRight = nodeRect.right - graphRect.left + 12;
-        const preferredLeft = nodeRect.left - graphRect.left - cardWidth - 12;
+        // Anchor from the text column instead of the graph lane so the left-side circles remain
+        // targetable while the hover is open.
+        const preferredRight = textRect.left - graphRect.left + 16;
+        const preferredLeft = textRect.right - graphRect.left - cardWidth - 16;
         const maxLeft = graphRect.width - cardWidth - 8;
         const left =
           preferredRight + cardWidth <= graphRect.width - 8
             ? preferredRight
             : Math.max(8, Math.min(preferredLeft, maxLeft));
-        const preferredTop = nodeRect.top - graphRect.top - 4;
-        const maxTop = graphRect.height - cardHeight - 8;
+        const preferredTop = nodeRect.bottom - graphRect.top - 6;
+        const viewportHeight =
+          window.innerHeight || document.documentElement.clientHeight;
+        const maxTop = viewportHeight - graphRect.top - cardHeight - 8;
         const top = Math.max(
           8,
           Math.min(preferredTop, Math.max(8, maxTop)),
@@ -375,6 +430,36 @@
               ),
             );
             value.append(buildCopyButton(change.commitId, "commit ID"));
+            if (change.contextValue) {
+              if (change.contextValue !== "zzzzzzzz") {
+                value.append(
+                  buildHoverActionButton(
+                    "Edit this change",
+                    "Edit this change",
+                    () => {
+                      vscode.postMessage({
+                        command: "editChange",
+                        changeId: change.contextValue,
+                      });
+                    },
+                    "codicon-edit",
+                  ),
+                );
+              }
+              value.append(
+                buildHoverActionButton(
+                  "New change",
+                  "Create and edit a new change with this revision as its parent",
+                  () => {
+                    vscode.postMessage({
+                      command: "newChangeFrom",
+                      changeId: change.contextValue,
+                    });
+                  },
+                  "codicon-git-branch-create",
+                ),
+              );
+            }
           });
         }
 
@@ -416,41 +501,52 @@
           });
         }
 
-        if (change.refName) {
-          appendHoverField(headerFields, "Ref", (value) => {
-            value.append(
-              buildMetaPill(
-                change.refName,
-                `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
-              ),
-            );
-          });
-        }
-
-        if (change.isEmpty || change.isConflict) {
-          appendHoverField(headerFields, "Status", (value) => {
-            if (change.isEmpty) {
-              value.append(buildMetaPill("empty", "status-pill empty"));
-            }
-            if (change.isConflict) {
-              value.append(buildMetaPill("conflict", "status-pill conflict"));
-            }
-          });
-        }
-
         hoverCard.appendChild(headerFields);
 
         // Reuse any fetched detail data so moving back onto the same node does not re-request
         // `jj show`, but still fall back to the compact row text before the detail round-trip
         // completes.
-        const cachedDescription = changeDetailsCache.get(change.contextValue);
+        const cachedDetails = changeDetailsCache.get(change.contextValue);
+        const statsText = formatChangeStats(cachedDetails?.stats);
+        if (statsText) {
+          const stats = document.createElement("div");
+          stats.className = "hover-stats";
+          stats.textContent = statsText;
+          hoverCard.appendChild(stats);
+        }
         const hoverDescription =
-          cachedDescription || change.fullDescription || change.description;
+          cachedDetails?.fullDescription ||
+          change.fullDescription ||
+          change.description;
         if (hoverDescription) {
           const description = document.createElement("div");
           description.className = `hover-description${change.hasDescription ? "" : " placeholder"}`;
           description.textContent = hoverDescription;
           hoverCard.appendChild(description);
+        }
+
+        if (change.refName || change.isEmpty || change.isConflict) {
+          const footer = document.createElement("div");
+          footer.className = "hover-footer";
+
+          if (change.refName) {
+            footer.append(
+              buildMetaPill(
+                change.refName,
+                `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
+              ),
+            );
+          }
+
+          if (change.isEmpty) {
+            footer.append(buildMetaPill("empty", "status-pill empty"));
+          }
+
+          if (change.isConflict) {
+            footer.append(buildMetaPill("conflict", "status-pill conflict"));
+          }
+
+          hoverCard.appendChild(footer);
         }
 
         hoverCard.hidden = false;
@@ -815,29 +911,6 @@
 
           textContent.append(summaryLine);
           node.appendChild(textContent);
-
-          // Create and append edit button
-          const editButton = document.createElement("button");
-          editButton.className = "edit-button";
-          editButton.innerHTML = '<i class="codicon codicon-log-in"></i>';
-          editButton.title = "Edit this change";
-          editButton.onclick = async (e) => {
-            e.stopPropagation();
-            // Just send the edit command and let updateGraph handle the cleanup
-            await vscode.postMessage({
-              command: "editChange",
-              changeId: change.contextValue,
-            });
-          };
-
-          // Hide edit button if this is the working copy or has ID "zzzzzzzz"
-          if (
-            change.contextValue === workingCopyId ||
-            change.contextValue === "zzzzzzzz"
-          ) {
-            editButton.style.display = "none";
-          }
-          node.appendChild(editButton);
           nodesContainer.appendChild(node);
 
           // Create circle and add it to SVG after node is in DOM
@@ -897,6 +970,14 @@
               command: "selectChange",
               selectedNodes: Array.from(selectedNodes),
             });
+
+            cancelHideHoverCard();
+            if (hoverShowTimer) {
+              clearTimeout(hoverShowTimer);
+              hoverShowTimer = null;
+            }
+            highlightConnectedNodes(node, true);
+            renderHoverCard(change, node);
           };
         });
 


### PR DESCRIPTION
## Related PRs

- #226: Match source control graph rows to jj log
- #227: Add source control graph hover details
- #228: Polish source control graph hover interactions

## Review Note

This PR is intentionally opened against `main` because I do not have permission to push stacked base
branches to `keanemind/jjk`.

It depends on the earlier graph row/layout and hover-detail work in #226 and #227, so GitHub will
show overlap from those PRs. For review, start with those earlier PRs and then focus on the
additional commits in this one.

## Problem

Once the hover exists, it still needs a few pieces of graph-specific polish to be genuinely useful
for day-to-day change inspection:

- change stats are missing
- graph actions still sit awkwardly on the row itself
- the hover needs better positioning and activation behavior for a narrow sidebar
- the graph highlight treatment is more aggressive than it needs to be

## Mental Model

This PR treats the hover as the place for graph-specific inspection and actions:

- add change stats from `repository.show(...)`
- move edit/new-change actions into the hover
- make the hover slower to trigger and easier to move onto
- tone down row hover/selection emphasis so the graph stays readable
- document the richer graph hover in the README

## Non-Goals

This PR does not add graph-to-diff navigation or graph customization settings.

## Tradeoffs

The hover still cannot escape the webview bounds, so this slice focuses on making the in-webview
experience practical rather than chasing native workbench behavior.

## Architecture Impact

- `src/graphWebview.ts`
  - adds diff summary data to the hover detail payload
  - handles hover actions for creating a new change from the selected revision
- `src/webview/graph.html`
  - renders stats, ref/status footer pills, and hover action buttons
  - adjusts hover positioning and activation timing for sidebar use
  - removes inline row edit chrome in favor of hover actions
- `src/webview/graph.css`
  - refines hover styling, action alignment, and graph emphasis levels
- `README.md`
  - documents the richer graph hover surface

## Observability

No new logging or telemetry.

## Tests

- `npm run compile`

## Documentation Deltas

- add a README feature bullet for the richer Source Control Graph hover

## Issue Coverage

Continues #149.

