### PR TITLE
Extract source control graph webview helpers

### DIFF
--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -9,6 +9,28 @@ type Message = {
   selectedNodes?: string[];
 };
 
+function buildChangeStats(
+  fileStatuses: Array<{ type: string }>,
+): {
+  total: number;
+  added: number;
+  modified: number;
+  removed: number;
+  renamed: number;
+  copied: number;
+} {
+  // Keep the hover payload aggregation in one place so the message contract stays aligned with the
+  // webview formatter when new file-status kinds are added.
+  return {
+    total: fileStatuses.length,
+    added: fileStatuses.filter((file) => file.type === "A").length,
+    modified: fileStatuses.filter((file) => file.type === "M").length,
+    removed: fileStatuses.filter((file) => file.type === "D").length,
+    renamed: fileStatuses.filter((file) => file.type === "R").length,
+    copied: fileStatuses.filter((file) => file.type === "C").length,
+  };
+}
+
 export class ChangeNode {
   // The parser keeps row metadata decomposed so the webview can lay out jj-style columns without
   // having to reverse-engineer a preformatted label string.
@@ -160,26 +182,13 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
             // Keep the list rows cheap to render by fetching the full description only when the
             // user asks for hover details on a specific change.
             const showResult = await this.repository.show(message.changeId);
-            const stats = {
-              total: showResult.fileStatuses.length,
-              added: showResult.fileStatuses.filter((file) => file.type === "A")
-                .length,
-              modified: showResult.fileStatuses.filter((file) => file.type === "M")
-                .length,
-              removed: showResult.fileStatuses.filter((file) => file.type === "D")
-                .length,
-              renamed: showResult.fileStatuses.filter((file) => file.type === "R")
-                .length,
-              copied: showResult.fileStatuses.filter((file) => file.type === "C")
-                .length,
-            };
             this.panel?.webview.postMessage({
               command: "changeDetails",
               changeId: message.changeId,
               details: {
                 fullDescription:
                   showResult.change.description || "(no description set)",
-                stats,
+                stats: buildChangeStats(showResult.fileStatuses),
               },
             });
           } catch {

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -357,6 +357,131 @@
         hoveredNode = null;
       }
 
+      function getTextContentRect(node) {
+        // Hover positioning is anchored from the text block rather than the graph lane so the
+        // circles remain clickable while the card is visible.
+        return (node.querySelector(".text-content") || node).getBoundingClientRect();
+      }
+
+      function getNodeCenter(node, svgRect) {
+        // The line and circle renderers both work in SVG coordinates, so centralize the DOM-to-SVG
+        // conversion instead of repeating slightly different formulas.
+        const nodeRect = node.getBoundingClientRect();
+        return {
+          nodeRect,
+          y: nodeRect.top - svgRect.top + nodeRect.height / 2,
+        };
+      }
+
+      function getLaneX(nodeRect, svgRect, symbolColumn) {
+        // jj lane routing is column-based, so keep the X calculation in one helper to make the
+        // connection and circle renderers share the same horizontal anchor.
+        return (
+          nodeRect.left -
+          svgRect.left +
+          graphLanePadding +
+          Number(symbolColumn || 0) * graphLaneStep
+        );
+      }
+
+      function appendHoverAuthorField(headerFields, change) {
+        if (!change.authorDisplay && !change.author) {
+          return;
+        }
+
+        // The compact row only shows the display name; the hover expands to the full
+        // display-name-plus-email representation for copyable detail.
+        appendHoverField(headerFields, "Author", (value) => {
+          const author = document.createElement("span");
+          author.className = "hover-author";
+          author.textContent = change.authorDisplay || change.author;
+          value.append(author);
+
+          if (change.author) {
+            const email = document.createElement("span");
+            email.className = "hover-email";
+            email.textContent = `<${change.author}>`;
+            value.append(email);
+          }
+        });
+      }
+
+      function appendHoverTimestampField(headerFields, change) {
+        if (!change.timestamp) {
+          return;
+        }
+
+        // Keep timestamp rendering in a dedicated helper so hover header fields remain easy to
+        // reorder without touching the shared field-row construction.
+        appendHoverField(headerFields, "Timestamp", (value) => {
+          const timestamp = document.createElement("span");
+          timestamp.className = "hover-timestamp";
+          timestamp.textContent = change.timestamp;
+          value.append(timestamp);
+        });
+      }
+
+      function appendHoverDescription(change, cachedDetails) {
+        // Prefer lazily fetched details, then fall back to the parser-provided description fields
+        // so the hover remains useful before the `jj show` round-trip completes.
+        const hoverDescription =
+          cachedDetails?.fullDescription ||
+          change.fullDescription ||
+          change.description;
+        if (!hoverDescription) {
+          return;
+        }
+
+        const description = document.createElement("div");
+        description.className = `hover-description${change.hasDescription ? "" : " placeholder"}`;
+        description.textContent = hoverDescription;
+        hoverCard.appendChild(description);
+      }
+
+      function appendHoverFooter(change) {
+        if (!change.refName && !change.isEmpty && !change.isConflict) {
+          return;
+        }
+
+        // Refs and status belong to the change as a whole rather than the field/value metadata, so
+        // keep them grouped in a footer instead of repeating more labeled rows.
+        const footer = document.createElement("div");
+        footer.className = "hover-footer";
+
+        if (change.refName) {
+          footer.append(
+            buildMetaPill(
+              change.refName,
+              `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
+            ),
+          );
+        }
+
+        if (change.isEmpty) {
+          footer.append(buildMetaPill("empty", "status-pill empty"));
+        }
+
+        if (change.isConflict) {
+          footer.append(buildMetaPill("conflict", "status-pill conflict"));
+        }
+
+        hoverCard.appendChild(footer);
+      }
+
+      function requestHoverDetailsIfNeeded(change) {
+        if (
+          change.contextValue &&
+          !changeDetailsCache.has(change.contextValue)
+        ) {
+          // Hover details are fetched lazily because they include the full description body, which
+          // is intentionally omitted from the compact graph log template.
+          vscode.postMessage({
+            command: "requestChangeDetails",
+            changeId: change.contextValue,
+          });
+        }
+      }
+
       function scheduleHideHoverCard() {
         if (hoverHideTimer) {
           clearTimeout(hoverHideTimer);
@@ -388,9 +513,7 @@
       function positionHoverCard(node) {
         const nodeRect = node.getBoundingClientRect();
         const graphRect = document.getElementById("graph").getBoundingClientRect();
-        const textContent =
-          node.querySelector(".text-content") || node;
-        const textRect = textContent.getBoundingClientRect();
+        const textRect = getTextContentRect(node);
         const cardWidth = hoverCard.offsetWidth || 0;
         const cardHeight = hoverCard.offsetHeight || 0;
         // Anchor from the text column instead of the graph lane so the left-side circles remain
@@ -476,30 +599,8 @@
           });
         }
 
-        if (change.authorDisplay || change.author) {
-          appendHoverField(headerFields, "Author", (value) => {
-            const author = document.createElement("span");
-            author.className = "hover-author";
-            author.textContent = change.authorDisplay || change.author;
-            value.append(author);
-
-            if (change.author) {
-              const email = document.createElement("span");
-              email.className = "hover-email";
-              email.textContent = `<${change.author}>`;
-              value.append(email);
-            }
-          });
-        }
-
-        if (change.timestamp) {
-          appendHoverField(headerFields, "Timestamp", (value) => {
-            const timestamp = document.createElement("span");
-            timestamp.className = "hover-timestamp";
-            timestamp.textContent = change.timestamp;
-            value.append(timestamp);
-          });
-        }
+        appendHoverAuthorField(headerFields, change);
+        appendHoverTimestampField(headerFields, change);
 
         hoverCard.appendChild(headerFields);
 
@@ -514,56 +615,14 @@
           stats.textContent = statsText;
           hoverCard.appendChild(stats);
         }
-        const hoverDescription =
-          cachedDetails?.fullDescription ||
-          change.fullDescription ||
-          change.description;
-        if (hoverDescription) {
-          const description = document.createElement("div");
-          description.className = `hover-description${change.hasDescription ? "" : " placeholder"}`;
-          description.textContent = hoverDescription;
-          hoverCard.appendChild(description);
-        }
-
-        if (change.refName || change.isEmpty || change.isConflict) {
-          const footer = document.createElement("div");
-          footer.className = "hover-footer";
-
-          if (change.refName) {
-            footer.append(
-              buildMetaPill(
-                change.refName,
-                `ref-name${isSpecialRefName(change.refName) ? " special-ref" : " bookmark-ref"}`,
-              ),
-            );
-          }
-
-          if (change.isEmpty) {
-            footer.append(buildMetaPill("empty", "status-pill empty"));
-          }
-
-          if (change.isConflict) {
-            footer.append(buildMetaPill("conflict", "status-pill conflict"));
-          }
-
-          hoverCard.appendChild(footer);
-        }
+        appendHoverDescription(change, cachedDetails);
+        appendHoverFooter(change);
 
         hoverCard.hidden = false;
         hoveredNode = node;
         positionHoverCard(node);
 
-        if (
-          change.contextValue &&
-          !changeDetailsCache.has(change.contextValue)
-        ) {
-          // Hover details are fetched lazily because they include the full description body, which
-          // is intentionally omitted from the compact graph log template.
-          vscode.postMessage({
-            command: "requestChangeDetails",
-            changeId: change.contextValue,
-          });
-        }
+        requestHoverDetailsIfNeeded(change);
       }
 
       function updateConnections() {
@@ -583,31 +642,23 @@
 
         nodes.forEach((node, index) => {
           const parentIds = JSON.parse(node.dataset.parentIds || "[]");
-          const nodeRect = node.getBoundingClientRect();
+          const { nodeRect, y: currentY } = getNodeCenter(node, svgRect);
           const currentColumn = Number(node.dataset.symbolColumn || "0");
 
           // Convert to SVG coordinates with vertical centering
-          const currentX =
-            nodeRect.left -
-            svgRect.left +
-            graphLanePadding +
-            currentColumn * graphLaneStep;
-          const currentY = nodeRect.top - svgRect.top + nodeRect.height / 2;
+          const currentX = getLaneX(nodeRect, svgRect, currentColumn);
 
           parentIds.forEach((parentId, index) => {
             const parentNode = nodeMap.get(parentId);
             if (parentNode) {
-              const parentRect = parentNode.getBoundingClientRect();
+              const { nodeRect: parentRect, y: parentY } = getNodeCenter(
+                parentNode,
+                svgRect,
+              );
               const parentColumn = Number(
                 parentNode.dataset.symbolColumn || "0",
               );
-              const parentX =
-                parentRect.left -
-                svgRect.left +
-                graphLanePadding +
-                parentColumn * graphLaneStep;
-              const parentY =
-                parentRect.top - svgRect.top + parentRect.height / 2;
+              const parentX = getLaneX(parentRect, svgRect, parentColumn);
 
               const path = document.createElementNS(
                 "http://www.w3.org/2000/svg",
@@ -927,12 +978,7 @@
           const svgRect = document
             .getElementById("connections")
             .getBoundingClientRect();
-          const x =
-            nodeRect.left -
-            svgRect.left +
-            graphLanePadding +
-            Number(change.symbolColumn || 0) * graphLaneStep -
-            6;
+          const x = getLaneX(nodeRect, svgRect, change.symbolColumn) - 6;
           const y = nodeRect.top - svgRect.top + nodeRect.height / 2 - 6; // -6 to account for circle radius
 
           circle.setAttribute("transform", `translate(${x}, ${y})`);
@@ -1016,8 +1062,7 @@
           );
 
           // Position the circle group
-          const x =
-            nodeRect.left - svgRect.left + graphLanePadding + symbolColumn * graphLaneStep - 6;
+          const x = getLaneX(nodeRect, svgRect, symbolColumn) - 6;
           const y = nodeRect.top - svgRect.top + nodeRect.height / 2 - 6;
           g.setAttribute("transform", `translate(${x}, ${y})`);
 


### PR DESCRIPTION
## Related PRs

- #226: Match source control graph rows to jj log
- #227: Add source control graph hover details
- #228: Polish source control graph hover interactions
- This PR: Extract graph webview helpers
- Follow-up: Keep graph row state out of dataset JSON

## Review Note

This PR is intentionally opened against `main` because I do not have permission to push stacked base
branches to `keanemind/jjk`.

It depends on the earlier graph row/layout and hover work in #226, #227, and #228, so GitHub will
show overlap from those PRs. Review it after those three and focus on the helper extraction commits
in this PR.

## Problem

The graph webview now has enough rendering and hover behavior that some of the hot paths are harder
to scan than they need to be. Geometry calculations, hover sections, and stats shaping are all
still correct, but they are spread inline through longer functions.

## Mental Model

This PR extracts the repeated pieces that already have a clear purpose:

- a helper for hover stats payload construction in the extension host
- small geometry helpers for lane X positions and node centers in the webview
- small hover rendering helpers for author/timestamp/description/footer sections
- a narrow helper for requesting hover details on demand

## Non-Goals

This PR does not change behavior and does not introduce a new graph layout model.

## Tradeoffs

The helpers stay in the existing files instead of splitting the webview into multiple modules. That
keeps the review small while still making the main render paths easier to follow.

## Architecture Impact

- `src/graphWebview.ts`
  - extracts a small helper for aggregating file-status stats
- `src/webview/graph.html`
  - extracts geometry helpers used by line and circle positioning
  - extracts hover rendering helpers for repeated field/body/footer sections

## Observability

No new logging or telemetry.

## Tests

- `npm run compile`

## Documentation Deltas

No public docs changed.
