### PR TITLE
Keep source control graph row state out of dataset JSON

### DIFF
--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -22,6 +22,9 @@
       let visibleChangeIds = [];
       let visibleCommitIds = [];
       const changeDetailsCache = new Map();
+      // Rich per-row state lives in JS rather than serialized DOM attributes. The map is rebuilt on
+      // every `updateGraph()` call, so it never outlives the current render.
+      const rowDataByChangeId = new Map();
       const graphLaneStep = 10;
       const graphLanePadding = 6;
       const hoverCard = document.getElementById("hover-card");
@@ -63,18 +66,13 @@
           case "changeDetails":
             if (message.changeId) {
               changeDetailsCache.set(message.changeId, message.details);
-              if (
-                hoveredNode &&
-                hoveredNode.dataset.changeId === message.changeId &&
-                !hoverCard.hidden
-              ) {
-                const hoveredChange = JSON.parse(
-                  hoveredNode.dataset.changePayload || "{}",
-                );
+              if (hoveredNode?.dataset.changeId === message.changeId && !hoverCard.hidden) {
+                // Update the current render's row snapshot so subsequent hover redraws can reuse
+                // the fetched description without another DOM serialization round-trip.
+                const hoveredChange = rowDataByChangeId.get(message.changeId);
                 if (message.details?.fullDescription) {
                   hoveredChange.fullDescription = message.details.fullDescription;
                 }
-                hoveredNode.dataset.changePayload = JSON.stringify(hoveredChange);
                 renderHoverCard(hoveredChange, hoveredNode);
               }
             }
@@ -384,6 +382,16 @@
         );
       }
 
+      function getRowData(changeId) {
+        return rowDataByChangeId.get(changeId);
+      }
+
+      function getParentIds(node) {
+        // Parent IDs are part of the render-scoped row state so callers can read them without
+        // reparsing JSON from `dataset`.
+        return getRowData(node.dataset.changeId)?.parentChangeIds || [];
+      }
+
       function appendHoverAuthorField(headerFields, change) {
         if (!change.authorDisplay && !change.author) {
           return;
@@ -641,7 +649,7 @@
         });
 
         nodes.forEach((node, index) => {
-          const parentIds = JSON.parse(node.dataset.parentIds || "[]");
+          const parentIds = getParentIds(node);
           const { nodeRect, y: currentY } = getNodeCenter(node, svgRect);
           const currentColumn = Number(node.dataset.symbolColumn || "0");
 
@@ -717,11 +725,11 @@
 
         if (highlight) {
           const nodeId = nodeElement.dataset.changeId;
-          const parentIds = JSON.parse(nodeElement.dataset.parentIds || "[]");
+          const parentIds = getParentIds(nodeElement);
 
           // Find child nodes (nodes that have this node as a parent)
           const childNodes = Array.from(nodes).filter((node) => {
-            const nodeParentIds = JSON.parse(node.dataset.parentIds || "[]");
+            const nodeParentIds = getParentIds(node);
             return nodeParentIds.includes(nodeId);
           });
           const childIds = childNodes.map((node) => node.dataset.changeId);
@@ -853,6 +861,8 @@
         const circlesContainer = document.getElementById("node-circles");
         nodesContainer.innerHTML = "";
         circlesContainer.innerHTML = "";
+        // Rebuild row state together with the DOM so refresh stays the single source of truth.
+        rowDataByChangeId.clear();
 
         const maxSymbolColumn = changes.reduce((max, change) => {
           return Math.max(max, Number(change.symbolColumn || 0));
@@ -887,10 +897,11 @@
           const node = document.createElement("div");
           node.className = "change-node";
           node.dataset.changeId = change.contextValue;
-          node.dataset.parentIds = JSON.stringify(change.parentChangeIds || []);
           node.dataset.branchType = change.branchType;
           node.dataset.symbolColumn = String(change.symbolColumn || 0);
-          node.dataset.changePayload = JSON.stringify(change);
+          // Store a shallow snapshot for hover/highlight logic; the DOM only keeps scalar lookup
+          // fields that are convenient for selectors and event targeting.
+          rowDataByChangeId.set(change.contextValue, { ...change });
 
           // Create text content container
           const textContent = document.createElement("div");


### PR DESCRIPTION
## Related PRs

- #226: Match source control graph rows to jj log
- #227: Add source control graph hover details
- #228: Polish source control graph hover interactions
- #229: Extract source control graph webview helpers
- This PR: Keep graph row state out of dataset JSON

## Review Note

This PR is intentionally opened against `main` because I do not have permission to push stacked base
branches to `keanemind/jjk`.

It depends on the earlier graph work in #226, #227, #228, and #229, so GitHub will show overlap
from those PRs. Review it after those four and focus on the state cleanup commits in this PR.

## Problem

The graph webview stores some row state in `dataset` fields and then reparses those JSON blobs in
multiple places. That works, but it makes hover and highlight paths noisier than they need to be.

## Mental Model

This PR keeps the DOM attributes for simple scalar lookup and moves richer per-row state into
small in-memory maps that are rebuilt on every `updateGraph()` call:

- `changeDetailsCache` still caches fetched hover details across hover opens
- `rowDataByChangeId` owns the current render's parent IDs and hover payload data
- `updateGraph()` clears and rebuilds the maps together with the DOM
- hover and highlight paths read from the in-memory state instead of reparsing JSON strings

## Non-Goals

This PR does not introduce a broader graph model or change the graph's behavior.

## Tradeoffs

The maps add a small amount of explicit render state, but that state is local to the webview and is
cleared during every full graph render. That is a simpler tradeoff than continuing to use the DOM as
an ad hoc serialization layer for rich row data.

## Architecture Impact

- `src/webview/graph.html`
  - replaces repeated `dataset` JSON parsing with small render-scoped maps
  - keeps map lifecycle tied to `updateGraph()` so refresh remains the source of truth

## Observability

No new logging or telemetry.

## Tests

- `npm run compile`

## Documentation Deltas

No public docs changed.
