### PR TITLE
Open full multi-file diffs from graph and SCM

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,12 @@
         "icon": "$(sign-in)"
       },
       {
+        "command": "jj.openResourceGroupChanges",
+        "title": "Open Changes",
+        "category": "Jujutsu",
+        "icon": "$(diff-multiple)"
+      },
+      {
         "command": "jj.restoreResourceState",
         "title": "Discard changes",
         "category": "Jujutsu",
@@ -290,29 +296,34 @@
       ],
       "scm/resourceGroup/context": [
         {
+          "command": "jj.openResourceGroupChanges",
+          "when": "scmProvider == jj",
+          "group": "inline@0"
+        },
+        {
           "command": "jj.describe",
           "when": "scmProvider == jj",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "jj.squashToParentResourceGroup",
           "when": "scmProvider == jj && scmResourceGroup == @",
-          "group": "inline"
+          "group": "inline@2"
         },
         {
           "command": "jj.squashToWorkingCopyResourceGroup",
           "when": "scmProvider == jj && scmResourceGroup != @",
-          "group": "inline"
+          "group": "inline@2"
         },
         {
           "command": "jj.restoreResourceGroup",
           "when": "scmProvider == jj",
-          "group": "inline"
+          "group": "inline@3"
         },
         {
           "command": "jj.editResourceGroup",
           "when": "scmProvider == jj && scmResourceGroup != @",
-          "group": "inline"
+          "group": "inline@4"
         }
       ],
       "scm/resourceState/context": [
@@ -410,6 +421,10 @@
         },
         {
           "command": "jj.restoreResourceGroup",
+          "when": "false"
+        },
+        {
+          "command": "jj.openResourceGroupChanges",
           "when": "false"
         },
         {

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -142,6 +142,19 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
 
     webviewView.webview.onDidReceiveMessage(async (message: Message) => {
       switch (message.command) {
+        case "openChanges":
+          try {
+            await vscode.commands.executeCommand(
+              "jj.openChangeDiff",
+              this.repository.repositoryRoot,
+              message.changeId,
+            );
+          } catch (error: unknown) {
+            vscode.window.showErrorMessage(
+              `Failed to open changes: ${error as string}`,
+            );
+          }
+          break;
         case "editChange":
           if (!message.changeId) {
             break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,141 @@ import {
 import { match } from "arktype";
 import { getActiveTextEditorDiff, pathEquals } from "./utils";
 
+/**
+ * Builds the multi-diff editor title used by graph row actions.
+ *
+ * The working copy row keeps a stable leading label while still surfacing the current
+ * change and commit IDs, so the tab matches the source control view without hiding the
+ * revision information users rely on to orient themselves.
+ */
+function getOpenChangeTitle(
+  label: string,
+  changeId: string,
+  commitId: string,
+  description: string,
+) {
+  const metadata = `[${changeId.substring(0, 8)}] • ${commitId.substring(0, 8)}`;
+  return description ? `${label} ${metadata} - ${description}` : `${label} ${metadata}`;
+}
+
+/**
+ * Maps a JJ file status entry to the original and modified resources expected by
+ * VS Code's multi-diff editor.
+ *
+ * Added and deleted files omit one side entirely, while renamed files resolve the
+ * original side from `renamedFrom` so the diff shows the full file move instead of
+ * comparing the new path against itself. The original side always uses
+ * `diffOriginalRev` so JJ can supply the correct diff baseline, including merge
+ * changes whose left side is not just the first parent. A modified revision of `@`
+ * still targets the live working tree rather than a historical `jj:` URI.
+ */
+function getMultiDiffUrisForFileStatus(
+  repository: JJRepository,
+  fileStatus: FileStatus,
+  originalRev: string | undefined,
+  modifiedRev: string | undefined,
+) {
+  const originalPath = fileStatus.renamedFrom
+    ? path.join(repository.repositoryRoot, fileStatus.renamedFrom)
+    : fileStatus.path;
+  const originalUri =
+    originalRev
+      ? toJJUri(vscode.Uri.file(originalPath), {
+          diffOriginalRev: originalRev,
+        })
+      : undefined;
+  const modifiedUri =
+    modifiedRev === "@"
+      ? vscode.Uri.file(fileStatus.path)
+      : modifiedRev
+        ? toJJUri(vscode.Uri.file(fileStatus.path), { rev: modifiedRev })
+        : undefined;
+
+  switch (fileStatus.type) {
+    case "A":
+      return {
+        originalUri: undefined,
+        modifiedUri,
+      };
+    case "D":
+      return {
+        originalUri,
+        modifiedUri: undefined,
+      };
+    default:
+      return {
+        originalUri,
+        modifiedUri,
+      };
+  }
+}
+
+/**
+ * Describes the full-repository diff that should be opened for a graph or SCM row.
+ *
+ * `originalRev` is the revision whose diff baseline should feed the left-hand resources
+ * through `diffOriginalRev`, while `modifiedRev` names the right-hand revision or live
+ * working tree to display. For the working copy, both selectors are `@`, but they are
+ * interpreted differently on each side of the multi-diff. `multiDiffSourceId` controls
+ * editor identity so working-copy reopens can produce a fresh editor input after the
+ * snapshot changes.
+ */
+type ChangeDiffTarget = {
+  title: string;
+  originalRev: string | undefined;
+  modifiedRev: string;
+  multiDiffSourceId: string;
+  fileStatuses: FileStatus[];
+};
+
+/**
+ * Resolves a graph or SCM row ID into the revision pair and file list needed for a
+ * full multi-diff editor.
+ *
+ * The working copy is a special case: it uses `getStatus(true)` so the right-hand side
+ * stays attached to the live workspace contents while the left-hand side resolves
+ * through `diffOriginalRev: "@"`. Historical changes use the change ID as the diff
+ * baseline too, which preserves JJ's multi-parent diff semantics instead of flattening
+ * merges to the first parent. The returned `multiDiffSourceId` is intentionally less
+ * stable for the working copy: it uses the current commit ID so reopening after new
+ * edits yields a fresh multi-diff input instead of reusing the previous snapshot tab.
+ */
+async function resolveChangeDiffTarget(
+  repository: JJRepository,
+  changeId: string,
+): Promise<ChangeDiffTarget> {
+  if (changeId === "@") {
+    // Keep the working copy view tied to the live tree instead of a frozen snapshot.
+    const status = await repository.getStatus(true);
+    return {
+      title: getOpenChangeTitle(
+        "Working Copy",
+        status.workingCopy.changeId,
+        status.workingCopy.commitId,
+        status.workingCopy.description,
+      ),
+      originalRev: "@",
+      modifiedRev: "@",
+      multiDiffSourceId: status.workingCopy.commitId,
+      fileStatuses: status.fileStatuses,
+    };
+  }
+
+  const show = await repository.show(changeId);
+  return {
+    title: getOpenChangeTitle(
+      show.change.changeId.substring(0, 8),
+      show.change.changeId,
+      show.change.commitId,
+      show.change.description,
+    ),
+    originalRev: show.change.changeId,
+    modifiedRev: show.change.changeId,
+    multiDiffSourceId: show.change.changeId,
+    fileStatuses: show.fileStatuses,
+  };
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   const outputChannel = vscode.window.createOutputChannel("Jujutsu Kaizen", {
     log: true,
@@ -363,6 +498,85 @@ export async function activate(context: vscode.ExtensionContext) {
     if (vscode.window.activeTextEditor) {
       void handleDidChangeActiveTextEditor(vscode.window.activeTextEditor);
     }
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "jj.openChangeDiff",
+        async (repositoryRoot: string, changeId: string) => {
+          try {
+            const repository = workspaceSCM.repoSCMs.find(
+              (repoSCM) => repoSCM.repositoryRoot === repositoryRoot,
+            )?.repository;
+            if (!repository) {
+              throw new Error("Repository not found");
+            }
+
+            const changeDiffTarget = await resolveChangeDiffTarget(
+              repository,
+              changeId,
+            );
+
+            if (changeDiffTarget.fileStatuses.length === 0) {
+              vscode.window.showInformationMessage("No changes to open.");
+              return;
+            }
+
+            // Match the Git graph behavior by opening the whole change in one multi-diff editor.
+            const resources = changeDiffTarget.fileStatuses.map((fileStatus) =>
+              getMultiDiffUrisForFileStatus(
+                repository,
+                fileStatus,
+                changeDiffTarget.originalRev,
+                changeDiffTarget.modifiedRev,
+              ),
+            );
+
+            const multiDiffSourceUri = vscode.Uri.from({
+              scheme: "jj-graph-change",
+              path: `${repository.repositoryRoot}/${changeDiffTarget.multiDiffSourceId}`,
+            });
+
+            await vscode.commands.executeCommand(
+              "_workbench.openMultiDiffEditor",
+              {
+                multiDiffSourceUri,
+                title: changeDiffTarget.title,
+                resources,
+              },
+            );
+          } catch (error) {
+            vscode.window.showErrorMessage(
+              `Failed to open changes${error instanceof Error ? `: ${error.message}` : ""}`,
+            );
+          }
+        },
+      ),
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "jj.openResourceGroupChanges",
+        async (resourceGroup: vscode.SourceControlResourceGroup) => {
+          try {
+            const repository =
+              workspaceSCM.getRepositoryFromResourceGroup(resourceGroup);
+            if (!repository) {
+              throw new Error("Repository not found");
+            }
+
+            await vscode.commands.executeCommand(
+              "jj.openChangeDiff",
+              repository.repositoryRoot,
+              resourceGroup.id,
+            );
+          } catch (error) {
+            vscode.window.showErrorMessage(
+              `Failed to open changes${error instanceof Error ? `: ${error.message}` : ""}`,
+            );
+          }
+        },
+      ),
+    );
 
     context.subscriptions.push(
       vscode.commands.registerCommand(

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -596,6 +596,11 @@ export class RepositorySourceControlManager {
       "@",
       "Working Copy",
     );
+    (
+      this.workingCopyResourceGroup as vscode.SourceControlResourceGroup & {
+        multiDiffEditorEnableViewChanges?: boolean;
+      }
+    ).multiDiffEditorEnableViewChanges = true;
     this.subscriptions.push(this.workingCopyResourceGroup);
 
     // Set up the SourceControlInputBox
@@ -782,6 +787,11 @@ export class RepositorySourceControlManager {
             parentChange,
           ),
         );
+        (
+          parentChangeResourceGroup as vscode.SourceControlResourceGroup & {
+            multiDiffEditorEnableViewChanges?: boolean;
+          }
+        ).multiDiffEditorEnableViewChanges = true;
         this.parentResourceGroups.push(parentChangeResourceGroup);
       } else {
         parentChangeResourceGroup = parentGroup;

--- a/src/webview/graph.css
+++ b/src/webview/graph.css
@@ -446,6 +446,44 @@ body {
   }
 }
 
+.action-buttons {
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  z-index: 2;
+}
+
+/* Row action styling */
+.action-button {
+  background: none;
+  border: none;
+  color: var(--vscode-button-foreground);
+  cursor: pointer;
+  padding: 2px 6px;
+  font-size: 0.9em;
+  border-radius: 3px;
+}
+
+.change-node:hover .action-buttons {
+  opacity: 1;
+}
+
+.action-button:hover {
+  background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.action-button .codicon {
+  color: var(--vscode-icon-foreground);
+}
+
+.action-button:hover .codicon {
+  color: var(--vscode-button-secondaryForeground);
+}
 /* Node circle styling */
 .node-circle {
   min-width: 12px;

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -977,6 +977,7 @@
 
           textContent.append(summaryLine);
           node.appendChild(textContent);
+          node.appendChild(createNodeActions(change, workingCopyId));
           nodesContainer.appendChild(node);
 
           // Create circle and add it to SVG after node is in DOM
@@ -1051,6 +1052,55 @@
             window.scrollTo(0, scrollTop);
           }
         });
+      }
+
+      function createNodeActions(change, workingCopyId) {
+        const actions = document.createElement("div");
+        actions.className = "action-buttons";
+
+        const openChangesButton = document.createElement("button");
+        openChangesButton.className = "action-button open-changes-button";
+        openChangesButton.innerHTML =
+          '<i class="codicon codicon-diff-multiple"></i>';
+        openChangesButton.title = "Open Changes";
+        openChangesButton.onclick = async (e) => {
+          e.stopPropagation();
+          await vscode.postMessage({
+            command: "openChanges",
+            // The working copy graph row uses the current change ID for display, but the
+            // extension command expects "@" to open the live working-tree diff.
+            changeId:
+              change.contextValue === workingCopyId ? "@" : change.contextValue,
+          });
+        };
+
+        if (change.contextValue === "zzzzzzzz") {
+          openChangesButton.style.display = "none";
+        }
+        actions.appendChild(openChangesButton);
+
+        const editButton = document.createElement("button");
+        editButton.className = "action-button edit-button";
+        editButton.innerHTML = '<i class="codicon codicon-log-in"></i>';
+        editButton.title = "Edit this change";
+        editButton.onclick = async (e) => {
+          e.stopPropagation();
+          // Just send the edit command and let updateGraph handle the cleanup
+          await vscode.postMessage({
+            command: "editChange",
+            changeId: change.contextValue,
+          });
+        };
+
+        if (
+          change.contextValue === workingCopyId ||
+          change.contextValue === "zzzzzzzz"
+        ) {
+          editButton.style.display = "none";
+        }
+        actions.appendChild(editButton);
+
+        return actions;
       }
 
       function updateCirclePositions() {


### PR DESCRIPTION
## Summary
- add an Open Changes action to graph rows and SCM resource groups
- open a full multi-file diff with the same diff icon and first-position ordering expected from Git
- preserve JJ diff baselines for working-copy and merge changes and use the working-copy commit ID so reopening after edits yields a fresh snapshot

## Verification
- npm run check-types
- npm run lint

## Follow-up
- local testing surfaced a separate rename/add edge case that appears to predate this PR and is not addressed here

Fixes https://github.com/keanemind/jjk/issues/95
