### PR TITLE
Fix diff-original file reads

### DIFF
--- a/src/fileSystemProvider.ts
+++ b/src/fileSystemProvider.ts
@@ -135,25 +135,11 @@ export class JJFileSystemProvider implements FileSystemProvider {
     this.cache.set(uri.toString(), cacheValue);
 
     if ("diffOriginalRev" in params) {
-      const originalContent = await repository.getDiffOriginal(
+      return await this.readDiffOriginalFile(
+        repository,
         params.diffOriginalRev,
         uri.fsPath,
       );
-      if (!originalContent) {
-        try {
-          const data = await repository.readFile(
-            params.diffOriginalRev,
-            uri.fsPath,
-          );
-          return data;
-        } catch (e) {
-          if (e instanceof Error && e.message.includes("No such path")) {
-            throw FileSystemError.FileNotFound();
-          }
-          throw e;
-        }
-      }
-      return originalContent;
     } else {
       try {
         const data = await repository.readFile(params.rev, uri.fsPath);
@@ -165,6 +151,138 @@ export class JJFileSystemProvider implements FileSystemProvider {
         throw e;
       }
     }
+  }
+
+  /**
+   * Resolves the left side of a diff-backed `jj:` URI such as
+   * `jj:/repo/file.txt?{"diffOriginalRev":"@"}`.
+   *
+   * For that URI, the editor wants the old side of the diff for `file.txt` in
+   * `@`. The same rule applies to any other revision string. This method first
+   * tries the parent side at the same path, then rename metadata from
+   * `show(rev)`, and finally the diff-tool fallback.
+   */
+  private async readDiffOriginalFile(
+    repository: NonNullable<
+      ReturnType<WorkspaceSourceControlManager["getRepositoryFromUri"]>
+    >,
+    rev: string,
+    filepath: string,
+  ): Promise<Uint8Array> {
+    const directContent = await this.tryReadDirectDiffOriginal(
+      repository,
+      rev,
+      filepath,
+    );
+    if (directContent) {
+      return directContent;
+    }
+
+    const renamedContent = await this.tryReadRenamedDiffOriginal(
+      repository,
+      rev,
+      filepath,
+    );
+    if (renamedContent) {
+      return renamedContent;
+    }
+
+    const originalContent = await repository.getDiffOriginal(rev, filepath);
+    if (originalContent) {
+      return originalContent;
+    }
+
+    throw FileSystemError.FileNotFound();
+  }
+
+  /**
+   * Tries the same path in the parent of the requested revision.
+   *
+   * Example: if the diff is for `@`, jj spells the parent side as `@-`, so
+   * this helper first tries `repository.readFile("@-", filepath)`. Other
+   * revision strings follow the same pattern.
+   *
+   * Returns `undefined` when that path is missing in the parent or when the
+   * parent expression resolves to multiple revisions.
+   */
+  private async tryReadDirectDiffOriginal(
+    repository: NonNullable<
+      ReturnType<WorkspaceSourceControlManager["getRepositoryFromUri"]>
+    >,
+    rev: string,
+    filepath: string,
+  ): Promise<Uint8Array | undefined> {
+    try {
+      return await repository.readFile(`${rev}-`, filepath);
+    } catch (e) {
+      if (this.isMissingOrAmbiguousDiffPath(e)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Tries to resolve the old content when the current path no longer matches
+   * the path in the parent revision.
+   *
+   * Example: if `show("@")` says `renamed-a.txt` came from `a.txt`, this
+   * helper probes the concrete parent commits with `/repo/a.txt`. Other
+   * revisions follow the same lookup flow.
+   */
+  private async tryReadRenamedDiffOriginal(
+    repository: NonNullable<
+      ReturnType<WorkspaceSourceControlManager["getRepositoryFromUri"]>
+    >,
+    rev: string,
+    filepath: string,
+  ): Promise<Uint8Array | undefined> {
+    const showResult = await repository.show(rev);
+    const fileStatus = showResult.fileStatuses.find((status) =>
+      pathEquals(status.path, filepath),
+    );
+    if (!fileStatus) {
+      return undefined;
+    }
+
+    const originalPath =
+      fileStatus.renamedFrom !== undefined
+        ? Uri.joinPath(
+            Uri.file(repository.repositoryRoot),
+            fileStatus.renamedFrom,
+          ).fsPath
+        : filepath;
+
+    for (const parentCommitId of showResult.change.parentCommitIds) {
+      try {
+        return await repository.readFile(parentCommitId, originalPath);
+      } catch (e) {
+        if (e instanceof Error && e.message.includes("No such path")) {
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Returns true when a direct parent-side read should fall through to rename
+   * handling instead of surfacing immediately.
+   *
+   * In practice that means either "this path does not exist in the parent" or
+   * "the parent expression matched more than one revision".
+   *
+   * This currently matches jj's human-readable error text, so it may need
+   * updating if jj changes those messages.
+   */
+  private isMissingOrAmbiguousDiffPath(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      (error.message.includes("No such path") ||
+        error.message.includes("resolved to more than one revision"))
+    );
   }
 
   writeFile(): void {

--- a/src/test/fileSystemProvider.test.ts
+++ b/src/test/fileSystemProvider.test.ts
@@ -85,4 +85,173 @@ suite("JJFileSystemProvider", () => {
       "Cache entry for an open jj:// document should survive cleanup",
     );
   });
+
+  test("diffOriginalRev reads directly from the original revision first", async function () {
+    const testFilePath = path.join(repoRoot, "deleted-file.txt");
+    const expected = Buffer.from("before delete\n");
+    let getDiffOriginalCalls = 0;
+
+    // Deleted files should resolve through `<rev>-` immediately. If this test
+    // reaches getDiffOriginal(), the provider skipped the cheap path.
+    const repository = {
+      readFile(rev: string, filepath: string): Promise<Uint8Array> {
+        assert.strictEqual(rev, "@-");
+        assert.strictEqual(filepath, testFilePath);
+        return Promise.resolve(expected);
+      },
+      getDiffOriginal(): Promise<Buffer | undefined> {
+        getDiffOriginalCalls += 1;
+        return Promise.resolve(Buffer.from("unexpected\n"));
+      },
+    };
+
+    const provider = workspaceSCM.fileSystemProvider;
+    const originalGetRepositoryFromUri = workspaceSCM.getRepositoryFromUri.bind(
+      workspaceSCM,
+    );
+
+    workspaceSCM.getRepositoryFromUri = () => repository as never;
+    try {
+      const data = await provider.readFile(
+        toJJUri(vscode.Uri.file(testFilePath), { diffOriginalRev: "@" }),
+      );
+      assert.deepStrictEqual(Buffer.from(data), expected);
+      assert.strictEqual(
+        getDiffOriginalCalls,
+        0,
+        "Expected direct readFile() to satisfy deleted-file reads",
+      );
+    } finally {
+      workspaceSCM.getRepositoryFromUri = originalGetRepositoryFromUri;
+    }
+  });
+
+  test("diffOriginalRev reads renamed content from the parent commit", async function () {
+    const renamedFilePath = path.join(repoRoot, "renamed-file.txt");
+    const originalFilePath = path.join(repoRoot, "old-name.txt");
+    const expected = Buffer.from("before rename\n");
+    let getDiffOriginalCalls = 0;
+    const readCalls: { rev: string; filepath: string }[] = [];
+
+    // Renames cannot be read from `<rev>-` at the new path, so the provider
+    // must use `show(rev)` metadata to map back to the old path in the parent.
+    const repository = {
+      repositoryRoot: repoRoot,
+      readFile(rev: string, filepath: string): Promise<Uint8Array> {
+        readCalls.push({ rev, filepath });
+        if (rev === "@-") {
+          return Promise.reject(new Error("No such path"));
+        }
+        assert.strictEqual(rev, "parent-1");
+        assert.strictEqual(filepath, originalFilePath);
+        return Promise.resolve(expected);
+      },
+      show() {
+        return Promise.resolve({
+          change: { parentCommitIds: ["parent-1"] },
+          fileStatuses: [
+            {
+              path: renamedFilePath,
+              renamedFrom: "old-name.txt",
+            },
+          ],
+        });
+      },
+      getDiffOriginal(rev: string, filepath: string): Promise<Buffer> {
+        getDiffOriginalCalls += 1;
+        assert.strictEqual(rev, "@");
+        assert.strictEqual(filepath, renamedFilePath);
+        return Promise.resolve(expected);
+      },
+    };
+
+    const provider = workspaceSCM.fileSystemProvider;
+    const originalGetRepositoryFromUri = workspaceSCM.getRepositoryFromUri.bind(
+      workspaceSCM,
+    );
+
+    workspaceSCM.getRepositoryFromUri = () => repository as never;
+    try {
+      const data = await provider.readFile(
+        toJJUri(vscode.Uri.file(renamedFilePath), { diffOriginalRev: "@" }),
+      );
+      assert.deepStrictEqual(Buffer.from(data), expected);
+      assert.deepStrictEqual(readCalls, [
+        { rev: "@-", filepath: renamedFilePath },
+        { rev: "parent-1", filepath: originalFilePath },
+      ]);
+      assert.strictEqual(getDiffOriginalCalls, 0);
+    } finally {
+      workspaceSCM.getRepositoryFromUri = originalGetRepositoryFromUri;
+    }
+  });
+
+  test(
+    "diffOriginalRev resolves renamed content across multiple parents",
+    async function () {
+      const renamedFilePath = path.join(repoRoot, "renamed-merge-file.txt");
+      const originalFilePath = path.join(repoRoot, "a.txt");
+      const expected = Buffer.from("before rename\n");
+      let getDiffOriginalCalls = 0;
+      const readCalls: { rev: string; filepath: string }[] = [];
+
+      // In merge commits, `@-` can be ambiguous. The provider should still
+      // resolve the rename by probing each concrete parent commit from
+      // `show(rev)` before falling back to diff extraction.
+      const repository = {
+        repositoryRoot: repoRoot,
+        readFile(rev: string, filepath: string): Promise<Uint8Array> {
+          readCalls.push({ rev, filepath });
+          if (rev === "@-") {
+            return Promise.reject(
+              new Error("Revset `@-` resolved to more than one revision"),
+            );
+          }
+          if (rev === "parent-1") {
+            return Promise.reject(new Error("No such path"));
+          }
+          assert.strictEqual(rev, "parent-2");
+          assert.strictEqual(filepath, originalFilePath);
+          return Promise.resolve(expected);
+        },
+        show() {
+          return Promise.resolve({
+            change: { parentCommitIds: ["parent-1", "parent-2"] },
+            fileStatuses: [
+              {
+                path: renamedFilePath,
+                renamedFrom: "a.txt",
+              },
+            ],
+          });
+        },
+        getDiffOriginal(rev: string, filepath: string): Promise<Buffer> {
+          getDiffOriginalCalls += 1;
+          assert.strictEqual(rev, "@");
+          assert.strictEqual(filepath, renamedFilePath);
+          return Promise.resolve(expected);
+        },
+      };
+
+      const provider = workspaceSCM.fileSystemProvider;
+      const originalGetRepositoryFromUri =
+        workspaceSCM.getRepositoryFromUri.bind(workspaceSCM);
+
+      workspaceSCM.getRepositoryFromUri = () => repository as never;
+      try {
+        const data = await provider.readFile(
+          toJJUri(vscode.Uri.file(renamedFilePath), { diffOriginalRev: "@" }),
+        );
+        assert.deepStrictEqual(Buffer.from(data), expected);
+        assert.deepStrictEqual(readCalls, [
+          { rev: "@-", filepath: renamedFilePath },
+          { rev: "parent-1", filepath: originalFilePath },
+          { rev: "parent-2", filepath: originalFilePath },
+        ]);
+        assert.strictEqual(getDiffOriginalCalls, 0);
+      } finally {
+        workspaceSCM.getRepositoryFromUri = originalGetRepositoryFromUri;
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary
Fix `jj:` diff-original reads so deleted and renamed files open without depending on the bundled fakeeditor binary.

## Problem
Clicking files in the changes pane could fail when the editor tried to open a URI like:

- `jj:/.../c.txt?{"diffOriginalRev":"@"}` for a deleted file
- `jj:/.../renamed-a.txt?{"diffOriginalRev":"@"}` for a renamed file

The failures I hit while reproducing this were:

1. Deleted files tried to go through the fakeeditor-backed diff path and failed with:
   `Error executing '.../fakeeditor_macos_aarch64' ... No such file or directory`
2. Renamed files also failed through the fakeeditor path.
3. In merge-parent cases, trying to read `@-` directly could fail first with:
   `Revset '@-' resolved to more than one revision`

That meant simple SCM file opens depended on fakeeditor even when jj already had enough information to read the old content directly.

## Fix
The file system provider now resolves `diffOriginalRev` URIs in three steps:

1. Try the same path in the parent side of the diff.
2. If that fails, use `show(rev)` rename metadata plus concrete parent commit IDs to find the old path.
3. Only fall back to `getDiffOriginal()` / fakeeditor for cases the normal reads still cannot resolve.

This keeps the fakeeditor path as a last resort instead of the default path for deleted and renamed SCM entries.

## Tests
Added coverage for:

- deleted files resolving directly from the parent side
- renamed files resolving through `show(rev)` metadata
- renamed files across multiple parents when `@-` is ambiguous

## Verification
- `npm run check-types`
- `npm run lint`
- `node esbuild.js`
