### PR TITLE
Upgrade fakeeditor for Zig 0.15

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,13 +5,27 @@
   "tasks": [
     {
       "label": "watch",
-      "dependsOn": ["npm: watch:tsc", "npm: watch:esbuild"],
+      "dependsOn": [
+        "npm: build:fakeeditor",
+        "npm: watch:tsc",
+        "npm: watch:esbuild"
+      ],
+      "dependsOrder": "sequence",
       "presentation": {
         "reveal": "never"
       },
       "group": {
         "kind": "build",
         "isDefault": true
+      }
+    },
+    {
+      "type": "npm",
+      "script": "build:fakeeditor",
+      "group": "build",
+      "label": "npm: build:fakeeditor",
+      "presentation": {
+        "reveal": "never"
       }
     },
     {

--- a/src/fakeeditor/build.zig
+++ b/src/fakeeditor/build.zig
@@ -31,10 +31,12 @@ pub fn build(b: *std.Build) void {
 
     const exe = b.addExecutable(.{
         .name = exe_name,
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
-        .link_libc = true,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
     });
 
     b.installArtifact(exe);

--- a/src/fakeeditor/build.zig.zon
+++ b/src/fakeeditor/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/src/fakeeditor/src/main.zig
+++ b/src/fakeeditor/src/main.zig
@@ -18,9 +18,7 @@ const POLLING_INTERVAL_MS: u64 = 50;
 const TOTAL_TIMEOUT_MS: u64 = 5000;
 
 // Helper function to check if a process exists on Windows
-fn parentProcessExistsWindows(parent_pid: c.DWORD) !bool {
-    const stderr = std.io.getStdErr().writer();
-
+fn parentProcessExistsWindows(parent_pid: c.DWORD, stderr: *std.Io.Writer) !bool {
     const hParentProcess = c.OpenProcess(c.SYNCHRONIZE, 0, parent_pid);
     if (hParentProcess == null) {
         // If we can't open the process, it might have already exited or we lack permissions.
@@ -39,18 +37,18 @@ fn parentProcessExistsWindows(parent_pid: c.DWORD) !bool {
     } else {
         // WAIT_FAILED or other error
         try stderr.print("WaitForSingleObject failed: {}\n", .{c.GetLastError()});
+        try stderr.flush();
         return false; // Assume parent is gone on error
     }
 }
 
 // Helper function to get parent PID on Windows
-fn getParentPidWindows() !c.DWORD {
-    const stderr = std.io.getStdErr().writer();
-
+fn getParentPidWindows(stderr: *std.Io.Writer) !c.DWORD {
     const current_pid = c.GetCurrentProcessId();
     const hSnapshot = c.CreateToolhelp32Snapshot(c.TH32CS_SNAPPROCESS, 0);
     if (hSnapshot == c.INVALID_HANDLE_VALUE) {
         try stderr.print("CreateToolhelp32Snapshot failed: {}\n", .{c.GetLastError()});
+        try stderr.flush();
         return error.SnapshotFailed;
     }
     defer _ = c.CloseHandle(hSnapshot);
@@ -60,6 +58,7 @@ fn getParentPidWindows() !c.DWORD {
 
     if (c.Process32First(hSnapshot, &pe32) == 0) { // BOOL is 0 for FALSE
         try stderr.print("Process32First failed: {}\n", .{c.GetLastError()});
+        try stderr.flush();
         return error.Process32FirstFailed;
     }
 
@@ -67,6 +66,7 @@ fn getParentPidWindows() !c.DWORD {
         if (pe32.th32ProcessID == current_pid) {
             if (pe32.th32ParentProcessID == 0) {
                 try stderr.print("Error: Retrieved parent PID is 0 for process {}. This is unexpected.\n", .{current_pid});
+                try stderr.flush();
                 return error.ParentIsSystemIdleProcess;
             }
             return pe32.th32ParentProcessID;
@@ -76,6 +76,7 @@ fn getParentPidWindows() !c.DWORD {
                 break; // Reached end of process list
             }
             try stderr.print("Process32Next failed: {}\n", .{c.GetLastError()});
+            try stderr.flush();
             return error.Process32NextFailed;
         }
     }
@@ -83,8 +84,12 @@ fn getParentPidWindows() !c.DWORD {
 }
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
-    const stderr = std.io.getStdErr().writer();
+    var stdout_buffer: [1024]u8 = undefined;
+    var stderr_buffer: [1024]u8 = undefined;
+    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    const stdout = &stdout_writer.interface;
+    const stderr = &stderr_writer.interface;
     const allocator = std.heap.page_allocator;
 
     const pid = switch (builtin.os.tag) {
@@ -109,16 +114,21 @@ pub fn main() !void {
     const envVarName = "JJ_FAKEEDITOR_SIGNAL_DIR";
     const signal_dir_path_owned = std.process.getEnvVarOwned(allocator, envVarName) catch |err| {
         try stderr.print("Error getting environment variable '{s}': {any}\n", .{ envVarName, err });
+        try stderr.flush();
+        try stdout.flush();
         std.process.exit(1);
     };
     defer allocator.free(signal_dir_path_owned);
 
     try stdout.print("FAKEEDITOR_OUTPUT_END\n", .{});
+    try stdout.flush();
 
     const start_time = std.time.nanoTimestamp();
 
     const signal_file_path = std.fs.path.join(allocator, &.{ signal_dir_path_owned, "0" }) catch |e| {
         try stderr.print("Critical Error: Failed to construct signal file path '{s}{c}{s}': {any}. Exiting fakeeditor.\n", .{ signal_dir_path_owned, std.fs.path.sep, "0", e });
+        try stderr.flush();
+        try stdout.flush();
         std.process.exit(1);
     };
 
@@ -129,8 +139,9 @@ pub fn main() !void {
     var parent_monitoring_active: bool = true;
 
     if (builtin.os.tag == .windows) {
-        win_ppid = getParentPidWindows() catch |err| blk: {
+        win_ppid = getParentPidWindows(stderr) catch |err| blk: {
             try stderr.print("Warning: Failed to get parent PID on Windows: {any}. Parent process monitoring will be disabled.\n", .{err});
+            try stderr.flush();
             parent_monitoring_active = false;
             break :blk 0;
         };
@@ -138,6 +149,8 @@ pub fn main() !void {
         ppid = c.getppid();
         if (ppid == 1) { // Reparented to init/launchd
             try stderr.print("Info: Parent process is init/launchd (PID 1), original parent likely exited. Exiting fakeeditor.\n", .{});
+            try stderr.flush();
+            stdout.flush() catch {};
             std.process.exit(1); // Exit immediately if reparented
         }
     }
@@ -148,14 +161,18 @@ pub fn main() !void {
 
         if (elapsed_ms >= TOTAL_TIMEOUT_MS) {
             try stderr.print("Error: Timeout ({}ms) reached in fakeeditor. Exiting.\n", .{TOTAL_TIMEOUT_MS});
+            try stderr.flush();
+            stdout.flush() catch {};
             std.process.exit(1);
         }
 
         // Parent Process Check
         if (parent_monitoring_active) {
             if (builtin.os.tag == .windows) {
-                if (!try parentProcessExistsWindows(win_ppid)) {
+                if (!try parentProcessExistsWindows(win_ppid, stderr)) {
                     try stderr.print("Parent process (PID: {}) no longer exists (Windows). Exiting.\n", .{win_ppid});
+                    try stderr.flush();
+                    stdout.flush() catch {};
                     std.process.exit(1);
                 }
             } else {
@@ -164,6 +181,8 @@ pub fn main() !void {
                 } else |err| {
                     if (err == error.NoSuchProcess) {
                         try stderr.print("Parent process (PID: {}) no longer exists (POSIX). Exiting.\n", .{ppid});
+                        try stderr.flush();
+                        stdout.flush() catch {};
                         std.process.exit(1);
                     }
                     // Other errors with kill could also indicate an issue, but NoSuchProcess is the key one.
@@ -176,14 +195,16 @@ pub fn main() !void {
         // Check for signal file "0"
         if (std.fs.accessAbsolute(signal_file_path, .{})) |_| {
             // File "0" exists
+            stdout.flush() catch {};
             std.process.exit(0);
         } else |err| {
             if (err != error.FileNotFound) {
                 // Some other error accessing the file, log it but continue polling
                 try stderr.print("Error checking for signal file '0' in fakeeditor: {any}\n", .{err});
+                try stderr.flush();
             }
         }
 
-        std.time.sleep(POLLING_INTERVAL_MS * std.time.ns_per_ms);
+        std.Thread.sleep(POLLING_INTERVAL_MS * std.time.ns_per_ms);
     }
 }


### PR DESCRIPTION
## Summary

This is a better fix than #235.

The deleted/renamed diff failures I hit locally were confounded by fakeeditor setup:

- the fakeeditor binary was missing in development
- `npm run build:fakeeditor` did not work with current Homebrew Zig
- the default VS Code extension launch path did not build fakeeditor first

This PR fixes that setup/runtime path instead of changing diff behavior.

## What changed

- update `src/fakeeditor/build.zig` to the Zig 0.15 build API (`root_module = b.createModule(...)`)
- bump `src/fakeeditor/build.zig.zon` minimum Zig version to `0.15.1`
- update `src/fakeeditor/src/main.zig` to Zig 0.15 buffered stdio writers
- flush buffered stdout/stderr before immediate exits so fakeeditor output is not lost
- replace `std.time.sleep(...)` with `std.Thread.sleep(...)`
- build fakeeditor from the default VS Code `watch` task so `Run Extension` has the helper binary available

## Zig 0.15 notes

The stdio changes follow the Zig 0.15.1 release notes:

- `std.fs.File.stdout().writer(&buffer)` / `stderr().writer(&buffer)`
- explicit flushing for buffered output

Release notes:
- https://ziglang.org/download/0.15.1/release-notes.html#upgrading-stdio-getstdoutwriterprint
- https://ziglang.org/download/0.15.1/release-notes.html#writergate

This works with current Homebrew Zig `0.15.2`, while the declared package minimum is `0.15.1`.

## Verification

- `npm run build:fakeeditor`
- `npm run check-types`
- `npm run lint`
