### PR TITLE
set npm version and add safety configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "typescript-eslint": "^8.20.0"
       },
       "engines": {
+        "npm": ">=11.10.0",
         "vscode": "^1.96.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "icon": "images/logo.png",
   "version": "0.9.3",
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.96.0",
+    "npm": ">=11.10.0"
   },
   "categories": [
     "SCM Providers"


### PR DESCRIPTION
[min-release-age](https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age) was added in [npm 11.10](https://github.com/npm/cli/releases/tag/v11.10.0)