### PR TITLE
Ignore working copy when fetching oplog

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -912,6 +912,7 @@ export class JJRepository {
           ...getPollIgnoreWorkingCopyArgs(this.repositoryRoot),
           "operation",
           "log",
+          "--ignore-working-copy",
           "--limit",
           "1",
           "-T",


### PR DESCRIPTION
There is no use in updating the working copy or making a snapshot when getting the oplog, and doing so pollutes the log, making using `jj undo` annoying.