### PR TITLE
Refactor parse status line

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2102,6 +2102,50 @@ export type Operation = {
   snapshot: boolean;
 };
 
+const changeRegex = /^(A|M|D|R|C) (.+)$/;
+
+/**
+ * Parses a single file status line matching the `A|M|D|R|C <path>` format
+ * produced by both `jj status` and `jj diff --summary`. Appends the result
+ * to `out`. Returns true if the line matched, false otherwise.
+ */
+export function parseFileStatusLine(
+  repositoryRoot: string,
+  line: string,
+  out: FileStatus[],
+): boolean {
+  const changeMatch = changeRegex.exec(line);
+  if (!changeMatch) {
+    return false;
+  }
+
+  const [_, type, file] = changeMatch;
+
+  if (type === "R" || type === "C") {
+    const parsedPaths = parseRenamePaths(file);
+    if (parsedPaths) {
+      out.push({
+        type: type,
+        file: parsedPaths.toPath,
+        path: path.join(repositoryRoot, parsedPaths.toPath),
+        renamedFrom: parsedPaths.fromPath,
+      });
+    } else {
+      throw new Error(
+        `Unexpected ${type === "R" ? "rename" : "copy"} line: ${line}`,
+      );
+    }
+  } else {
+    const normalizedFile = path.normalize(file).replace(/\\/g, "/");
+    out.push({
+      type: type as "A" | "M" | "D",
+      file: normalizedFile,
+      path: path.join(repositoryRoot, normalizedFile),
+    });
+  }
+  return true;
+}
+
 async function parseJJStatus(
   repositoryRoot: string,
   output: string,
@@ -2118,7 +2162,6 @@ async function parseJJStatus(
   };
   const parentCommits: Change[] = [];
 
-  const changeRegex = /^(A|M|D|R|C) (.+)$/;
   const commitRegex =
     /^(Working copy|Parent commit)\s*(\(@-?\))?\s*:\s+(\S+)\s+(\S+)(?:\s+(.+?)\s+\|)?(?:\s+(.*))?$/;
 
@@ -2172,32 +2215,9 @@ async function parseJJStatus(
       }
     }
 
-    const changeMatch = changeRegex.exec(ansiStrippedTrimmedLine);
-    if (changeMatch) {
-      const [_, type, file] = changeMatch;
-
-      if (type === "R" || type === "C") {
-        const parsedPaths = parseRenamePaths(file);
-        if (parsedPaths) {
-          fileStatuses.push({
-            type: type,
-            file: parsedPaths.toPath,
-            path: path.join(repositoryRoot, parsedPaths.toPath),
-            renamedFrom: parsedPaths.fromPath,
-          });
-        } else {
-          throw new Error(
-            `Unexpected ${type === "R" ? "rename" : "copy"} line: ${line}`,
-          );
-        }
-      } else {
-        const normalizedFile = path.normalize(file).replace(/\\/g, "/");
-        fileStatuses.push({
-          type: type as "A" | "M" | "D",
-          file: normalizedFile,
-          path: path.join(repositoryRoot, normalizedFile),
-        });
-      }
+    if (
+      parseFileStatusLine(repositoryRoot, ansiStrippedTrimmedLine, fileStatuses)
+    ) {
       continue;
     }
 

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert";
+import * as path from "path";
 import { getExtensionAPI } from "./extensionApi";
+import type { FileStatus } from "../repository";
 
 suite("parseRenamePaths", () => {
   let parseRenamePaths: (
@@ -106,5 +108,80 @@ suite("parseRenamePaths", () => {
   test("should return null for empty input", () => {
     const input = "";
     assert.strictEqual(parseRenamePaths(input), null);
+  });
+});
+
+suite("parseFileStatusLine", () => {
+  let parseFileStatusLine: (
+    repositoryRoot: string,
+    line: string,
+    out: FileStatus[],
+  ) => boolean;
+
+  const root = "/repo";
+
+  suiteSetup(async () => {
+    ({ parseFileStatusLine } = (await getExtensionAPI()).repository);
+  });
+
+  test("parses added file", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(parseFileStatusLine(root, "A src/new.ts", out), true);
+    assert.deepStrictEqual(out, [
+      { type: "A", file: "src/new.ts", path: path.join(root, "src/new.ts") },
+    ]);
+  });
+
+  test("parses modified file", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "M lib/utils.ts", out);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].type, "M");
+    assert.strictEqual(out[0].file, "lib/utils.ts");
+  });
+
+  test("parses deleted file", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "D old-file.txt", out);
+    assert.strictEqual(out[0].type, "D");
+  });
+
+  test("parses rename with brace syntax", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "R src/{old => new}/file.ts", out);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].type, "R");
+    assert.strictEqual(out[0].file, "src/new/file.ts");
+    assert.strictEqual(out[0].renamedFrom, "src/old/file.ts");
+  });
+
+  test("parses copy", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "C src/{a => b}.ts", out);
+    assert.strictEqual(out[0].type, "C");
+    assert.strictEqual(out[0].renamedFrom, "src/a.ts");
+  });
+
+  test("returns false for non-matching line", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(
+      parseFileStatusLine(root, "Working copy : abc123", out),
+      false,
+    );
+    assert.strictEqual(out.length, 0);
+  });
+
+  test("returns false for empty line", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(parseFileStatusLine(root, "", out), false);
+  });
+
+  test("appends to existing array", () => {
+    const out: FileStatus[] = [
+      { type: "A", file: "existing.ts", path: path.join(root, "existing.ts") },
+    ];
+    parseFileStatusLine(root, "M second.ts", out);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[1].type, "M");
   });
 });

--- a/src/test/scm.test.ts
+++ b/src/test/scm.test.ts
@@ -73,8 +73,7 @@ suite("SCM Integration Tests", () => {
     await vscode.commands.executeCommand("jj.refresh");
 
     // Verify the file shows up in the working copy resource group
-    const workingCopyStates =
-      repoSCM.workingCopyResourceGroup.resourceStates;
+    const workingCopyStates = repoSCM.workingCopyResourceGroup.resourceStates;
     const addedFile = workingCopyStates.find((state) =>
       state.resourceUri.fsPath.endsWith(testFileName),
     );


### PR DESCRIPTION
:wave: Hello! I'm a new contributor to this repo. I'm also fairly new to TypeScript and VS Code extensions (I usually work deeper in the backend).

I also used AI fairly substantially in writing this, but I did my best to understand the code and be responsible for it as I went along; this is not 'one shot' vibe-coded, I did substantial editing and revising to do my best to make it clean, maintainable code, and reviewed it myself carefully; that said, I don't work much in Typescript, so my review was more structural than stylistic / language idioms. Comments / feedback very welcome!

## Overall Goal

This is the first PR in a small stack that builds toward a "base comparison" feature. I wanted to be able to see a diff from _any_ base commit, defaulting to `trunk()`. That way you could, for example, see the diff for a whole PR in the SCM sidebar.

This first PR is just a foundational refactor.

## Summary

- Extract `parseFileStatusLine()` from the inline logic in `parseJJStatus`, so it can be reused by a new `diffSummary()` method in a later PR (both `jj status` and `jj diff --summary` produce the same `A|M|D|R|C <path>` format)
- Add unit tests for `parseFileStatusLine` covering added, modified, deleted, rename, copy, non-matching lines, empty lines, and appending to an existing array

## Test plan

- [x] Unit tests for `parseFileStatusLine` (8 cases)
- [x] Existing tests still pass
