### PR TITLE
Show parent commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -481,6 +481,12 @@
           "default": true,
           "description": "Whether the periodic poll command (jj operation log) should snapshot the working copy. When enabled, file changes are automatically detected; when disabled, modified files may not auto-update until the next manual jj command.",
           "scope": "resource"
+        },
+        "jjk.showParentCommit": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show Parent Commit resource groups in the SCM sidebar.",
+          "scope": "resource"
         }
       }
     },

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2102,6 +2102,50 @@ export type Operation = {
   snapshot: boolean;
 };
 
+const changeRegex = /^(A|M|D|R|C) (.+)$/;
+
+/**
+ * Parses a single file status line matching the `A|M|D|R|C <path>` format
+ * produced by both `jj status` and `jj diff --summary`. Appends the result
+ * to `out`. Returns true if the line matched, false otherwise.
+ */
+export function parseFileStatusLine(
+  repositoryRoot: string,
+  line: string,
+  out: FileStatus[],
+): boolean {
+  const changeMatch = changeRegex.exec(line);
+  if (!changeMatch) {
+    return false;
+  }
+
+  const [_, type, file] = changeMatch;
+
+  if (type === "R" || type === "C") {
+    const parsedPaths = parseRenamePaths(file);
+    if (parsedPaths) {
+      out.push({
+        type: type,
+        file: parsedPaths.toPath,
+        path: path.join(repositoryRoot, parsedPaths.toPath),
+        renamedFrom: parsedPaths.fromPath,
+      });
+    } else {
+      throw new Error(
+        `Unexpected ${type === "R" ? "rename" : "copy"} line: ${line}`,
+      );
+    }
+  } else {
+    const normalizedFile = path.normalize(file).replace(/\\/g, "/");
+    out.push({
+      type: type as "A" | "M" | "D",
+      file: normalizedFile,
+      path: path.join(repositoryRoot, normalizedFile),
+    });
+  }
+  return true;
+}
+
 async function parseJJStatus(
   repositoryRoot: string,
   output: string,
@@ -2118,7 +2162,6 @@ async function parseJJStatus(
   };
   const parentCommits: Change[] = [];
 
-  const changeRegex = /^(A|M|D|R|C) (.+)$/;
   const commitRegex =
     /^(Working copy|Parent commit)\s*(\(@-?\))?\s*:\s+(\S+)\s+(\S+)(?:\s+(.+?)\s+\|)?(?:\s+(.*))?$/;
 
@@ -2172,32 +2215,9 @@ async function parseJJStatus(
       }
     }
 
-    const changeMatch = changeRegex.exec(ansiStrippedTrimmedLine);
-    if (changeMatch) {
-      const [_, type, file] = changeMatch;
-
-      if (type === "R" || type === "C") {
-        const parsedPaths = parseRenamePaths(file);
-        if (parsedPaths) {
-          fileStatuses.push({
-            type: type,
-            file: parsedPaths.toPath,
-            path: path.join(repositoryRoot, parsedPaths.toPath),
-            renamedFrom: parsedPaths.fromPath,
-          });
-        } else {
-          throw new Error(
-            `Unexpected ${type === "R" ? "rename" : "copy"} line: ${line}`,
-          );
-        }
-      } else {
-        const normalizedFile = path.normalize(file).replace(/\\/g, "/");
-        fileStatuses.push({
-          type: type as "A" | "M" | "D",
-          file: normalizedFile,
-          path: path.join(repositoryRoot, normalizedFile),
-        });
-      }
+    if (
+      parseFileStatusLine(repositoryRoot, ansiStrippedTrimmedLine, fileStatuses)
+    ) {
       continue;
     }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -688,19 +688,27 @@ export class RepositorySourceControlManager {
       }
     }
 
-    const parentShowPromises = status.parentChanges.map(
-      async (parentChange) => {
-        const showResult = await this.repository.show(parentChange.changeId);
-        return { changeId: parentChange.changeId, showResult };
-      },
+    const config = vscode.workspace.getConfiguration(
+      "jjk",
+      vscode.Uri.file(this.repositoryRoot),
     );
+    const showParentCommit = config.get<boolean>("showParentCommit") ?? true;
 
-    const parentShowResultsArray = await Promise.all(parentShowPromises);
+    if (showParentCommit) {
+      const parentShowPromises = status.parentChanges.map(
+        async (parentChange) => {
+          const showResult = await this.repository.show(parentChange.changeId);
+          return { changeId: parentChange.changeId, showResult };
+        },
+      );
 
-    for (const { changeId, showResult } of parentShowResultsArray) {
-      newParentShowResults.set(changeId, showResult);
-      newFileStatusesByChange.set(changeId, showResult.fileStatuses);
-      newConflictedFilesByChange.set(changeId, showResult.conflictedFiles);
+      const parentShowResultsArray = await Promise.all(parentShowPromises);
+
+      for (const { changeId, showResult } of parentShowResultsArray) {
+        newParentShowResults.set(changeId, showResult);
+        newFileStatusesByChange.set(changeId, showResult.fileStatuses);
+        newConflictedFilesByChange.set(changeId, showResult.conflictedFiles);
+      }
     }
 
     this.status = status;
@@ -751,9 +759,33 @@ export class RepositorySourceControlManager {
     );
     this.sourceControl.count = this.status.fileStatuses.length;
 
+    this.renderParentCommits(this.status);
+
+    this.decorationProvider.onRefresh(
+      this.repositoryRoot,
+      this.fileStatusesByChange,
+      this.trackedFiles,
+      this.conflictedFilesByChange,
+    );
+  }
+
+  private renderParentCommits(status: RepositoryStatus) {
+    const config = vscode.workspace.getConfiguration(
+      "jjk",
+      vscode.Uri.file(this.repositoryRoot),
+    );
+
+    if (!config.get<boolean>("showParentCommit", true)) {
+      for (const group of this.parentResourceGroups) {
+        group.dispose();
+      }
+      this.parentResourceGroups = [];
+      return;
+    }
+
     const updatedGroups: vscode.SourceControlResourceGroup[] = [];
     for (const group of this.parentResourceGroups) {
-      const parentChange = this.status.parentChanges.find(
+      const parentChange = status.parentChanges.find(
         (change) => change.changeId === group.id,
       );
       if (!parentChange) {
@@ -768,7 +800,7 @@ export class RepositorySourceControlManager {
     }
     this.parentResourceGroups = updatedGroups;
 
-    for (const parentChange of this.status.parentChanges) {
+    for (const parentChange of this.status!.parentChanges) {
       let parentChangeResourceGroup!: vscode.SourceControlResourceGroup;
 
       const parentGroup = this.parentResourceGroups.find(
@@ -789,8 +821,8 @@ export class RepositorySourceControlManager {
 
       const showResult = this.parentShowResults.get(parentChange.changeId);
       if (showResult) {
-        parentChangeResourceGroup.resourceStates = showResult.fileStatuses.map(
-          (parentStatus) => {
+        parentChangeResourceGroup.resourceStates =
+          showResult.fileStatuses.map((parentStatus) => {
             return {
               resourceUri: toJJUri(vscode.Uri.file(parentStatus.path), {
                 rev: parentChange.changeId,
@@ -810,17 +842,9 @@ export class RepositorySourceControlManager {
                 `(${parentChange.changeId})`,
               ),
             };
-          },
-        );
+          });
       }
     }
-
-    this.decorationProvider.onRefresh(
-      this.repositoryRoot,
-      this.fileStatusesByChange,
-      this.trackedFiles,
-      this.conflictedFilesByChange,
-    );
   }
 
   dispose() {

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert";
+import * as path from "path";
 import { getExtensionAPI } from "./extensionApi";
+import type { FileStatus } from "../repository";
 
 suite("parseRenamePaths", () => {
   let parseRenamePaths: (
@@ -106,5 +108,80 @@ suite("parseRenamePaths", () => {
   test("should return null for empty input", () => {
     const input = "";
     assert.strictEqual(parseRenamePaths(input), null);
+  });
+});
+
+suite("parseFileStatusLine", () => {
+  let parseFileStatusLine: (
+    repositoryRoot: string,
+    line: string,
+    out: FileStatus[],
+  ) => boolean;
+
+  const root = "/repo";
+
+  suiteSetup(async () => {
+    ({ parseFileStatusLine } = (await getExtensionAPI()).repository);
+  });
+
+  test("parses added file", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(parseFileStatusLine(root, "A src/new.ts", out), true);
+    assert.deepStrictEqual(out, [
+      { type: "A", file: "src/new.ts", path: path.join(root, "src/new.ts") },
+    ]);
+  });
+
+  test("parses modified file", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "M lib/utils.ts", out);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].type, "M");
+    assert.strictEqual(out[0].file, "lib/utils.ts");
+  });
+
+  test("parses deleted file", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "D old-file.txt", out);
+    assert.strictEqual(out[0].type, "D");
+  });
+
+  test("parses rename with brace syntax", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "R src/{old => new}/file.ts", out);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].type, "R");
+    assert.strictEqual(out[0].file, "src/new/file.ts");
+    assert.strictEqual(out[0].renamedFrom, "src/old/file.ts");
+  });
+
+  test("parses copy", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "C src/{a => b}.ts", out);
+    assert.strictEqual(out[0].type, "C");
+    assert.strictEqual(out[0].renamedFrom, "src/a.ts");
+  });
+
+  test("returns false for non-matching line", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(
+      parseFileStatusLine(root, "Working copy : abc123", out),
+      false,
+    );
+    assert.strictEqual(out.length, 0);
+  });
+
+  test("returns false for empty line", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(parseFileStatusLine(root, "", out), false);
+  });
+
+  test("appends to existing array", () => {
+    const out: FileStatus[] = [
+      { type: "A", file: "existing.ts", path: path.join(root, "existing.ts") },
+    ];
+    parseFileStatusLine(root, "M second.ts", out);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[1].type, "M");
   });
 });

--- a/src/test/scm.test.ts
+++ b/src/test/scm.test.ts
@@ -73,8 +73,7 @@ suite("SCM Integration Tests", () => {
     await vscode.commands.executeCommand("jj.refresh");
 
     // Verify the file shows up in the working copy resource group
-    const workingCopyStates =
-      repoSCM.workingCopyResourceGroup.resourceStates;
+    const workingCopyStates = repoSCM.workingCopyResourceGroup.resourceStates;
     const addedFile = workingCopyStates.find((state) =>
       state.resourceUri.fsPath.endsWith(testFileName),
     );


### PR DESCRIPTION
Second PR in the stack (builds on #251). This one adds the ability to toggle the existing parent commit groups on and off. On its own, this isn't that useful; why would you turn them off? But in PR 3, there's an option (default off) to have a customizable base to diff against, and this makes more sense then - you might want `(trunk()..@-)` and `(@-..@)` as the two revsets shown on the right.

## Summary

- Add `jjk.showParentCommit` setting (default: `true`) to control whether parent commit resource groups appear in the SCM sidebar
- When disabled, parent groups are disposed and the `jj show` calls for parents are skipped entirely
- Extract a `reconcileGroups()` helper that disposes stale resource groups whose IDs are no longer in the active set — this replaces the inline dispose-and-rebuild loop in `render()` and will be reused by the base comparison groups in PR 3

## UX Choices

The UX choice made here is an option to turn parent off / on; it's a somewhat minimal change to existing functionality. Then the next PR builds on that, by adding a configurable third resource group.

Arguably... a better UX would be to be able to _choose_ additional bases arbitrarily; there would be a built-in one for '@-' which would be the base for the working copy; a default-on one for '@--' which would be the parent; and you could then e.g. add a 'trunk()' which would then add diffs for that. That said, that is (1) more complicated, and (2) also gets tricky with merge commits. Hence the choice made here. But I'm interested in your thoughts here!

## Why a separate PR?

Well, mainly to keep things small and independently reviewable.

The `showParentCommit` toggle is marginally useful on its own (some users only care about the working copy diff), and it introduces the `reconcileGroups` pattern that the base comparison feature builds on.

## Test plan

- [x] Manual: toggle `jjk.showParentCommit` off → parent groups disappear, back on → they return
- [x] Manual: with setting off, status bar and working copy still refresh correctly
- [x] Existing tests still pass
