### PR TITLE
Add base comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,12 @@
         "title": "Open child change",
         "category": "Jujutsu",
         "icon": "$(arrow-right)"
+      },
+      {
+        "command": "jj.changeBaseRevision",
+        "title": "Change base revision",
+        "category": "Jujutsu",
+        "icon": "$(git-compare)"
       }
     ],
     "menus": {
@@ -287,12 +293,17 @@
           "command": "jj.new",
           "when": "scmProvider == jj",
           "group": "navigation"
+        },
+        {
+          "command": "jj.changeBaseRevision",
+          "when": "scmProvider == jj && config.jjk.showBaseComparison",
+          "group": "navigation"
         }
       ],
       "scm/resourceGroup/context": [
         {
           "command": "jj.describe",
-          "when": "scmProvider == jj",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
           "group": "inline"
         },
         {
@@ -302,17 +313,22 @@
         },
         {
           "command": "jj.squashToWorkingCopyResourceGroup",
-          "when": "scmProvider == jj && scmResourceGroup != @",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
           "group": "inline"
         },
         {
           "command": "jj.restoreResourceGroup",
-          "when": "scmProvider == jj",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
           "group": "inline"
         },
         {
           "command": "jj.editResourceGroup",
-          "when": "scmProvider == jj && scmResourceGroup != @",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
+          "group": "inline"
+        },
+        {
+          "command": "jj.changeBaseRevision",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^base-comparison-/",
           "group": "inline"
         }
       ],
@@ -324,7 +340,7 @@
         },
         {
           "command": "jj.restoreResourceState",
-          "when": "scmProvider == jj",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
           "group": "inline"
         },
         {
@@ -339,14 +355,14 @@
         },
         {
           "command": "jj.squashToWorkingCopyResourceState",
-          "when": "scmProvider == jj && scmResourceGroup != @",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
           "group": "inline"
         }
       ],
       "scm/resourceFolder/context": [
         {
           "command": "jj.restoreResourceState",
-          "when": "scmProvider == jj",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
           "group": "inline"
         },
         {
@@ -356,7 +372,7 @@
         },
         {
           "command": "jj.squashToWorkingCopyResourceState",
-          "when": "scmProvider == jj && scmResourceGroup != @",
+          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
           "group": "inline"
         }
       ],
@@ -486,6 +502,18 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to show Parent Commit resource groups in the SCM sidebar.",
+          "scope": "resource"
+        },
+        "jjk.showBaseComparison": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to show Base Comparison resource groups in the SCM sidebar. Shows cumulative changes from the base revision to the current branch position.",
+          "scope": "resource"
+        },
+        "jjk.baseRevision": {
+          "type": "string",
+          "default": "trunk()",
+          "description": "Revset expression for the base of the comparison. Used by the Base Comparison resource group.",
           "scope": "resource"
         }
       }

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
       "scm/resourceGroup/context": [
         {
           "command": "jj.describe",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds",
           "group": "inline"
         },
         {
@@ -313,22 +313,22 @@
         },
         {
           "command": "jj.squashToWorkingCopyResourceGroup",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds && scmResourceGroup != @",
           "group": "inline"
         },
         {
           "command": "jj.restoreResourceGroup",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds",
           "group": "inline"
         },
         {
           "command": "jj.editResourceGroup",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds && scmResourceGroup != @",
           "group": "inline"
         },
         {
           "command": "jj.changeBaseRevision",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^base-comparison-/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.baseComparisonGroupIds",
           "group": "inline"
         }
       ],
@@ -340,7 +340,7 @@
         },
         {
           "command": "jj.restoreResourceState",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds",
           "group": "inline"
         },
         {
@@ -355,14 +355,14 @@
         },
         {
           "command": "jj.squashToWorkingCopyResourceState",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds && scmResourceGroup != @",
           "group": "inline"
         }
       ],
       "scm/resourceFolder/context": [
         {
           "command": "jj.restoreResourceState",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^(@|[a-z]+)$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds",
           "group": "inline"
         },
         {
@@ -372,7 +372,7 @@
         },
         {
           "command": "jj.squashToWorkingCopyResourceState",
-          "when": "scmProvider == jj && scmResourceGroup =~ /^[a-z]+$/",
+          "when": "scmProvider == jj && scmResourceGroup in jj.commitGroupIds && scmResourceGroup != @",
           "group": "inline"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -481,6 +481,12 @@
           "default": true,
           "description": "Whether the periodic poll command (jj operation log) should snapshot the working copy. When enabled, file changes are automatically detected; when disabled, modified files may not auto-update until the next manual jj command.",
           "scope": "resource"
+        },
+        "jjk.showParentCommit": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to show Parent Commit resource groups in the SCM sidebar.",
+          "scope": "resource"
         }
       }
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,6 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
           await repoSCM.checkForUpdates();
         }),
       );
+      updateScmGroupContextKeys();
     }
   });
 
@@ -564,10 +565,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
               let statuses: FileStatus[];
               if (scm.workingCopyResourceGroup === resourceGroup) {
-                if (!scm.status) {
+                if (!scm.snapshot?.status) {
                   throw new Error("No current working copy change found");
                 }
-                const repositoryStatus = scm.status;
+                const repositoryStatus = scm.snapshot.status;
 
                 statuses = resourceStates.map((resourceState) => {
                   const foundStatus = repositoryStatus.fileStatuses.find(
@@ -582,7 +583,7 @@ export async function activate(context: vscode.ExtensionContext) {
                   return foundStatus;
                 });
               } else if (scm.parentResourceGroups.includes(resourceGroup)) {
-                const show = scm.parentShowResults.get(resourceGroup.id);
+                const show = scm.snapshot?.parentShowResults.get(resourceGroup.id);
                 if (!show) {
                   throw new Error(
                     "No current parent change show result found for the resource group",
@@ -1497,6 +1498,35 @@ export async function activate(context: vscode.ExtensionContext) {
     // Snapshot changes
     await Promise.all(
       workspaceSCM.repoSCMs.map((repoSCM) => repoSCM.checkForUpdates()),
+    );
+
+    updateScmGroupContextKeys();
+  }
+
+  /**
+   * Sets VS Code context keys that identify which SCM resource groups are
+   * commit groups vs base comparison groups. This is used in package.json
+   * when clauses via the `in` operator (e.g. `scmResourceGroup in
+   * jj.commitGroupIds`) to reliably control which buttons appear on each
+   * group type — more robust than regex matching on group IDs.
+   */
+  function updateScmGroupContextKeys() {
+    const commitGroupIds = workspaceSCM.repoSCMs.flatMap((repo) => [
+      repo.workingCopyResourceGroup.id,
+      ...repo.parentResourceGroups.map((g) => g.id),
+    ]);
+    const baseComparisonGroupIds = workspaceSCM.repoSCMs.flatMap((repo) =>
+      repo.baseComparisonGroups.map((g) => g.id),
+    );
+    vscode.commands.executeCommand(
+      "setContext",
+      "jj.commitGroupIds",
+      commitGroupIds,
+    );
+    vscode.commands.executeCommand(
+      "setContext",
+      "jj.baseComparisonGroupIds",
+      baseComparisonGroupIds,
     );
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,20 @@ export async function activate(context: vscode.ExtensionContext) {
         await checkReposFunction(affectedFolders);
       }
     }
+
+    if (
+      e.affectsConfiguration("jjk.baseRevision") ||
+      e.affectsConfiguration("jjk.showBaseComparison") ||
+      e.affectsConfiguration("jjk.showParentCommit")
+    ) {
+      // Reset operationId to force re-fetch with new config values
+      await Promise.all(
+        workspaceSCM.repoSCMs.map(async (repoSCM) => {
+          repoSCM.operationId = undefined;
+          await repoSCM.checkForUpdates();
+        }),
+      );
+    }
   });
 
   let isInitialized = false;
@@ -1493,9 +1507,63 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
   );
 
-  // Stub: full QuickPick implementation added in a later commit
   context.subscriptions.push(
-    vscode.commands.registerCommand("jj.changeBaseRevision", () => {}),
+    vscode.commands.registerCommand("jj.changeBaseRevision", async () => {
+      const repository = getSelectedRepo();
+
+      const config = vscode.workspace.getConfiguration(
+        "jjk",
+        vscode.Uri.file(repository.repositoryRoot),
+      );
+      const showParentCommit = config.get<boolean>("showParentCommit") ?? true;
+
+      const items: vscode.QuickPickItem[] = [
+        { label: "trunk()", description: "Default: main branch" },
+      ];
+      // Only show @- when parent commit groups are hidden,
+      // since otherwise the parent is already visible in the SCM view
+      if (!showParentCommit) {
+        items.push({ label: "@-", description: "Parent commit" });
+      }
+
+      // Fetch bookmarks between the
+      const bookmarks = await repository.bookmarksOfAncestors();
+      for (const b of bookmarks) {
+        items.push({ label: b, description: "bookmark" });
+      }
+
+      items.push({
+        label: "$(edit) Custom revset...",
+        description: "Enter any revset expression",
+      });
+
+      const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: "Select base revision",
+      });
+      if (!selected) {
+        return;
+      }
+
+      let value = selected.label;
+      if (value === "$(edit) Custom revset...") {
+        const currentBase = config.get<string>("baseRevision") ?? "trunk()";
+        const custom = await vscode.window.showInputBox({
+          prompt: "Enter a jj revset expression for the base revision",
+          value: currentBase,
+          placeHolder: "trunk()",
+        });
+        if (custom === undefined) {
+          return;
+        }
+        value = custom;
+      }
+
+      await config.update(
+        "baseRevision",
+        value,
+        vscode.ConfigurationTarget.Workspace,
+      );
+    }),
   );
 
   context.subscriptions.push(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1493,6 +1493,11 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
   );
 
+  // Stub: full QuickPick implementation added in a later commit
+  context.subscriptions.push(
+    vscode.commands.registerCommand("jj.changeBaseRevision", () => {}),
+  );
+
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "jj.openFolderGitSettings",

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2102,6 +2102,50 @@ export type Operation = {
   snapshot: boolean;
 };
 
+const changeRegex = /^(A|M|D|R|C) (.+)$/;
+
+/**
+ * Parses a single file status line matching the `A|M|D|R|C <path>` format
+ * produced by both `jj status` and `jj diff --summary`. Appends the result
+ * to `out`. Returns true if the line matched, false otherwise.
+ */
+export function parseFileStatusLine(
+  repositoryRoot: string,
+  line: string,
+  out: FileStatus[],
+): boolean {
+  const changeMatch = changeRegex.exec(line);
+  if (!changeMatch) {
+    return false;
+  }
+
+  const [_, type, file] = changeMatch;
+
+  if (type === "R" || type === "C") {
+    const parsedPaths = parseRenamePaths(file);
+    if (parsedPaths) {
+      out.push({
+        type: type,
+        file: parsedPaths.toPath,
+        path: path.join(repositoryRoot, parsedPaths.toPath),
+        renamedFrom: parsedPaths.fromPath,
+      });
+    } else {
+      throw new Error(
+        `Unexpected ${type === "R" ? "rename" : "copy"} line: ${line}`,
+      );
+    }
+  } else {
+    const normalizedFile = path.normalize(file).replace(/\\/g, "/");
+    out.push({
+      type: type as "A" | "M" | "D",
+      file: normalizedFile,
+      path: path.join(repositoryRoot, normalizedFile),
+    });
+  }
+  return true;
+}
+
 async function parseJJStatus(
   repositoryRoot: string,
   output: string,
@@ -2118,7 +2162,6 @@ async function parseJJStatus(
   };
   const parentCommits: Change[] = [];
 
-  const changeRegex = /^(A|M|D|R|C) (.+)$/;
   const commitRegex =
     /^(Working copy|Parent commit)\s*(\(@-?\))?\s*:\s+(\S+)\s+(\S+)(?:\s+(.+?)\s+\|)?(?:\s+(.*))?$/;
 
@@ -2172,32 +2215,9 @@ async function parseJJStatus(
       }
     }
 
-    const changeMatch = changeRegex.exec(ansiStrippedTrimmedLine);
-    if (changeMatch) {
-      const [_, type, file] = changeMatch;
-
-      if (type === "R" || type === "C") {
-        const parsedPaths = parseRenamePaths(file);
-        if (parsedPaths) {
-          fileStatuses.push({
-            type: type,
-            file: parsedPaths.toPath,
-            path: path.join(repositoryRoot, parsedPaths.toPath),
-            renamedFrom: parsedPaths.fromPath,
-          });
-        } else {
-          throw new Error(
-            `Unexpected ${type === "R" ? "rename" : "copy"} line: ${line}`,
-          );
-        }
-      } else {
-        const normalizedFile = path.normalize(file).replace(/\\/g, "/");
-        fileStatuses.push({
-          type: type as "A" | "M" | "D",
-          file: normalizedFile,
-          path: path.join(repositoryRoot, normalizedFile),
-        });
-      }
+    if (
+      parseFileStatusLine(repositoryRoot, ansiStrippedTrimmedLine, fileStatuses)
+    ) {
       continue;
     }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -473,7 +473,8 @@ export class WorkspaceSourceControlManager {
     return this.repoSCMs.find((repo) => {
       return (
         resourceGroup === repo.workingCopyResourceGroup ||
-        repo.parentResourceGroups.includes(resourceGroup)
+        repo.parentResourceGroups.includes(resourceGroup) ||
+        repo.baseComparisonGroups.includes(resourceGroup)
       );
     })?.repository;
   }
@@ -495,7 +496,8 @@ export class WorkspaceSourceControlManager {
     return this.repoSCMs.find(
       (repo) =>
         repo.workingCopyResourceGroup === resourceGroup ||
-        repo.parentResourceGroups.includes(resourceGroup),
+        repo.parentResourceGroups.includes(resourceGroup) ||
+        repo.baseComparisonGroups.includes(resourceGroup),
     );
   }
 
@@ -508,6 +510,7 @@ export class WorkspaceSourceControlManager {
       const groups = [
         repo.workingCopyResourceGroup,
         ...repo.parentResourceGroups,
+        ...repo.baseComparisonGroups,
       ];
 
       for (const group of groups) {
@@ -575,6 +578,54 @@ export class RepositorySourceControlManager {
   trackedFiles: Set<string> = new Set();
   status: RepositoryStatus | undefined;
   parentShowResults: Map<string, Show> = new Map();
+
+  // Base comparison state — kept in a dedicated field so it can be split
+  // into a separate refresh cycle later without restructuring render().
+  baseComparisonGroups: vscode.SourceControlResourceGroup[] = [];
+  baseComparisonResults: Map<
+    string,
+    { fileStatuses: FileStatus[]; toRevision: string; error?: string }
+  > = new Map();
+
+  /**
+   * Determines the "--to" revision for the base comparison, implementing the
+   * additive model: base covers trunk()→@--, parent covers @--→@-, working
+   * copy covers @-→@. Returns null if the base comparison should be suppressed
+   * (merge commits, where the additive property can't be maintained).
+   */
+  static getBaseComparisonTarget(
+    status: RepositoryStatus,
+    parentShowResults: Map<string, Show>,
+    showParentCommit: boolean,
+  ): string | null {
+    const parents = status.parentChanges;
+
+    // Merge commit at @: multiple parents, additive model breaks down
+    if (parents.length !== 1) {
+      return null;
+    }
+
+    const parentChangeId = parents[0].changeId;
+
+    if (showParentCommit) {
+      // Target is parent's parent (@--). Get it from the show() result.
+      const parentShow = parentShowResults.get(parentChangeId);
+      if (!parentShow) {
+        return null;
+      }
+
+      const grandparentIds = parentShow.change.parentChangeIds;
+      // Parent is a merge commit: additive model breaks down
+      if (grandparentIds.length !== 1) {
+        return null;
+      }
+
+      return grandparentIds[0];
+    } else {
+      // Parent hidden: target is @- itself
+      return parentChangeId;
+    }
+  }
 
   constructor(
     public repositoryRoot: string,
@@ -693,6 +744,9 @@ export class RepositorySourceControlManager {
       vscode.Uri.file(this.repositoryRoot),
     );
     const showParentCommit = config.get<boolean>("showParentCommit") ?? true;
+    const showBaseComparison =
+      config.get<boolean>("showBaseComparison") ?? false;
+    const baseRevision = config.get<string>("baseRevision") ?? "trunk()";
 
     if (showParentCommit) {
       const parentShowPromises = status.parentChanges.map(
@@ -711,10 +765,65 @@ export class RepositorySourceControlManager {
       }
     }
 
+    // Base comparison: fetch diff from base revision to the additive target.
+    // This runs after parent show() completes because getBaseComparisonTarget
+    // needs parentShowResults to determine @-- (the parent's parent).
+    const newBaseComparisonResults = new Map<
+      string,
+      { fileStatuses: FileStatus[]; toRevision: string; error?: string }
+    >();
+
+    if (showBaseComparison) {
+      const toRevision = RepositorySourceControlManager.getBaseComparisonTarget(
+        status,
+        newParentShowResults,
+        showParentCommit,
+      );
+
+      if (toRevision !== null) {
+        try {
+          const fileStatuses = await this.repository.diffSummary(
+            baseRevision,
+            toRevision,
+          );
+          newBaseComparisonResults.set("base-comparison", {
+            fileStatuses,
+            toRevision,
+          });
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          // Parse jj's "error: <detail>" stderr format; falls back to a
+          // truncated message if jj ever changes its output format.
+          const shortMessage =
+            message.match(/error:\s*([\s\S]+?)(?:\n|$)/i)?.[1] ??
+            message.substring(0, 80);
+          newBaseComparisonResults.set("base-comparison", {
+            fileStatuses: [],
+            toRevision,
+            error: shortMessage,
+          });
+          logger.warn(
+            `Base comparison failed for revset "${baseRevision}": ${message}`,
+          );
+        }
+      }
+    }
+
+    // Add base comparison file statuses to the map so the decoration provider
+    // can show A/M/D badges. The key is the toRevision (the revision used in
+    // the resourceUri), which matches how provideFileDecoration extracts the
+    // rev from jj:// URIs.
+    for (const [, result] of newBaseComparisonResults) {
+      if (!result.error) {
+        newFileStatusesByChange.set(result.toRevision, result.fileStatuses);
+      }
+    }
+
     this.status = status;
     this.fileStatusesByChange = newFileStatusesByChange;
     this.conflictedFilesByChange = newConflictedFilesByChange;
     this.parentShowResults = newParentShowResults;
+    this.baseComparisonResults = newBaseComparisonResults;
     this.trackedFiles = newTrackedFiles;
   }
 
@@ -759,7 +868,20 @@ export class RepositorySourceControlManager {
     );
     this.sourceControl.count = this.status.fileStatuses.length;
 
-    this.renderParentCommits(this.status);
+    const config = vscode.workspace.getConfiguration(
+      "jjk",
+      vscode.Uri.file(this.repositoryRoot),
+    );
+    const showParentCommit =
+      config.get<boolean>("showParentCommit") ?? true;
+    const showBaseComparison =
+      config.get<boolean>("showBaseComparison") ?? false;
+    const baseRevision =
+      config.get<string>("baseRevision") ?? "trunk()";
+
+    this.renderParentCommits(this.status, showParentCommit);
+
+    this.renderBaseComparison(showBaseComparison, baseRevision);
 
     this.decorationProvider.onRefresh(
       this.repositoryRoot,
@@ -769,13 +891,11 @@ export class RepositorySourceControlManager {
     );
   }
 
-  private renderParentCommits(status: RepositoryStatus) {
-    const config = vscode.workspace.getConfiguration(
-      "jjk",
-      vscode.Uri.file(this.repositoryRoot),
-    );
-
-    if (!config.get<boolean>("showParentCommit", true)) {
+  private renderParentCommits(
+    status: RepositoryStatus,
+    showParentCommit: boolean,
+  ) {
+    if (!showParentCommit) {
       for (const group of this.parentResourceGroups) {
         group.dispose();
       }
@@ -847,6 +967,62 @@ export class RepositorySourceControlManager {
     }
   }
 
+  private renderBaseComparison(
+    showBaseComparison: boolean,
+    baseRevision: string,
+  ) {
+    this.baseComparisonGroups = reconcileGroups(
+      this.baseComparisonGroups,
+      new Set(this.baseComparisonResults.keys()),
+    );
+
+    if (!showBaseComparison) {
+      for (const group of this.baseComparisonGroups) {
+        group.dispose();
+      }
+      this.baseComparisonGroups = [];
+      return;
+    }
+
+    for (const [groupId, result] of this.baseComparisonResults) {
+      let group = this.baseComparisonGroups.find((g) => g.id === groupId);
+      if (!group) {
+        // New group - create now, fill details in below
+        group = this.sourceControl.createResourceGroup(groupId, "");
+        this.baseComparisonGroups.push(group);
+      }
+
+      if (result.error) {
+        group.label = `Changes since ${baseRevision} (error: ${result.error})`;
+        group.resourceStates = [];
+        continue;
+      }
+
+      group.label = `Changes since ${baseRevision}`;
+      group.resourceStates = result.fileStatuses.map((fileStatus) => {
+        const leftUri = toJJUri(vscode.Uri.file(fileStatus.path), {
+          rev: baseRevision,
+        });
+        const rightUri = toJJUri(vscode.Uri.file(fileStatus.path), {
+          rev: result.toRevision,
+        });
+        return {
+          resourceUri: rightUri,
+          decorations: {
+            strikeThrough: fileStatus.type === "D",
+            tooltip: path.basename(fileStatus.file),
+          },
+          command: getResourceStateCommand(
+            fileStatus,
+            leftUri,
+            rightUri,
+            `(${baseRevision})`,
+          ),
+        };
+      });
+    }
+  }
+
   dispose() {
     for (const subscription of this.subscriptions) {
       subscription.dispose();
@@ -854,7 +1030,28 @@ export class RepositorySourceControlManager {
     for (const group of this.parentResourceGroups) {
       group.dispose();
     }
+    for (const group of this.baseComparisonGroups) {
+      group.dispose();
+    }
   }
+}
+
+/**
+ * Dispose resource groups whose IDs are no longer valid and return the rest.
+ */
+function reconcileGroups(
+  groups: vscode.SourceControlResourceGroup[],
+  validIds: Set<string>,
+): vscode.SourceControlResourceGroup[] {
+  const kept: vscode.SourceControlResourceGroup[] = [];
+  for (const group of groups) {
+    if (validIds.has(group.id)) {
+      kept.push(group);
+    } else {
+      group.dispose();
+    }
+  }
+  return kept;
 }
 
 function getResourceStateCommand(
@@ -1315,6 +1512,32 @@ export class JJRepository {
         },
       ),
     );
+  }
+
+  /**
+   * Returns the file statuses between two revisions using `jj diff --summary`.
+   * Uses spawnJJRead (--ignore-working-copy) since the poll cycle already
+   * snapshots the working copy before this is called.
+   */
+  async diffSummary(from: string, to: string): Promise<FileStatus[]> {
+    const output = (
+      await handleJJCommand(
+        this.spawnJJRead(["diff", "--summary", "--from", from, "--to", to], {
+          defaultTimeout: 10_000,
+        }),
+      )
+    ).toString();
+
+    const fileStatuses: FileStatus[] = [];
+    for (const rawLine of output.split("\n")) {
+      const line = rawLine.trim();
+      if (!line) {
+        continue;
+      }
+      // jj diff --summary output is plain ASCII (no ANSI color codes)
+      parseFileStatusLine(this.repositoryRoot, line, fileStatuses);
+    }
+    return fileStatuses;
   }
 
   async describeRetryImmutable(rev: string, message: string) {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -559,6 +559,50 @@ export function provideOriginalResource(uri: vscode.Uri) {
   return originalUri;
 }
 
+type BaseComparisonResult =
+  | { kind: "ok"; fileStatuses: FileStatus[]; toRevision: string }
+  | { kind: "error"; toRevision: string; error: string };
+
+/** Settings that affect both data fetching and rendering, read once per cycle. */
+type RefreshConfig = {
+  showParentCommit: boolean;
+  showBaseComparison: boolean;
+  baseRevision: string;
+};
+
+/**
+ * Immutable snapshot of all repo state computed in a single refresh cycle.
+ * Assigned atomically so readers never see a mix of stale and fresh data.
+ */
+type RepoSnapshot = {
+  status: RepositoryStatus;
+  fileStatusesByChange: Map<string, FileStatus[]>;
+  conflictedFilesByChange: Map<string, Set<string>>;
+  parentShowResults: Map<string, Show>;
+  baseComparisonResult: BaseComparisonResult | undefined;
+  trackedFiles: Set<string>;
+};
+
+/**
+ * Filters an array of resource groups, disposing those not in `validIds` and
+ * returning the survivors. Used by render() to reconcile both parent commit
+ * and base comparison groups against the latest data.
+ */
+function reconcileGroups(
+  groups: vscode.SourceControlResourceGroup[],
+  validIds: Set<string>,
+): vscode.SourceControlResourceGroup[] {
+  const kept: vscode.SourceControlResourceGroup[] = [];
+  for (const group of groups) {
+    if (validIds.has(group.id)) {
+      kept.push(group);
+    } else {
+      group.dispose();
+    }
+  }
+  return kept;
+}
+
 export class RepositorySourceControlManager {
   subscriptions: {
     dispose(): unknown;
@@ -573,19 +617,9 @@ export class RepositorySourceControlManager {
   readonly onDidUpdate: vscode.Event<void> = this._onDidUpdate.event;
 
   operationId: string | undefined; // the latest operation id seen by this manager
-  fileStatusesByChange: Map<string, FileStatus[]> = new Map();
-  conflictedFilesByChange: Map<string, Set<string>> = new Map();
-  trackedFiles: Set<string> = new Set();
-  status: RepositoryStatus | undefined;
-  parentShowResults: Map<string, Show> = new Map();
+  snapshot: RepoSnapshot | undefined;
 
-  // Base comparison state — kept in a dedicated field so it can be split
-  // into a separate refresh cycle later without restructuring render().
   baseComparisonGroups: vscode.SourceControlResourceGroup[] = [];
-  baseComparisonResults: Map<
-    string,
-    { fileStatuses: FileStatus[]; toRevision: string; error?: string }
-  > = new Map();
 
   /**
    * Determines the "--to" revision for the base comparison, implementing the
@@ -711,20 +745,34 @@ export class RepositorySourceControlManager {
       this.operationId = latestOperationId;
       const status = await this.repository.status();
 
-      await this.updateState(status);
-      this.render();
+      const vsConfig = vscode.workspace.getConfiguration(
+        "jjk",
+        vscode.Uri.file(this.repositoryRoot),
+      );
+      const config: RefreshConfig = {
+        showParentCommit: vsConfig.get<boolean>("showParentCommit") ?? true,
+        showBaseComparison:
+          vsConfig.get<boolean>("showBaseComparison") ?? false,
+        baseRevision: vsConfig.get<string>("baseRevision") ?? "trunk()",
+      };
+
+      this.snapshot = await this.buildSnapshot(status, config);
+      this.render(config);
 
       this._onDidUpdate.fire(undefined);
     }
   }
 
-  async updateState(status: RepositoryStatus) {
-    const newTrackedFiles = new Set<string>();
-    const newParentShowResults = new Map<string, Show>();
-    const newFileStatusesByChange = new Map<string, FileStatus[]>([
+  async buildSnapshot(
+    status: RepositoryStatus,
+    config: RefreshConfig,
+  ): Promise<RepoSnapshot> {
+    const trackedFiles = new Set<string>();
+    const parentShowResults = new Map<string, Show>();
+    const fileStatusesByChange = new Map<string, FileStatus[]>([
       ["@", status.fileStatuses],
     ]);
-    const newConflictedFilesByChange = new Map<string, Set<string>>([
+    const conflictedFilesByChange = new Map<string, Set<string>>([
       ["@", status.conflictedFiles],
     ]);
 
@@ -734,21 +782,12 @@ export class RepositorySourceControlManager {
       let currentPath = this.repositoryRoot + path.sep;
       for (const p of pathParts) {
         currentPath += p;
-        newTrackedFiles.add(currentPath);
+        trackedFiles.add(currentPath);
         currentPath += path.sep;
       }
     }
 
-    const config = vscode.workspace.getConfiguration(
-      "jjk",
-      vscode.Uri.file(this.repositoryRoot),
-    );
-    const showParentCommit = config.get<boolean>("showParentCommit") ?? true;
-    const showBaseComparison =
-      config.get<boolean>("showBaseComparison") ?? false;
-    const baseRevision = config.get<string>("baseRevision") ?? "trunk()";
-
-    if (showParentCommit) {
+    if (config.showParentCommit) {
       const parentShowPromises = status.parentChanges.map(
         async (parentChange) => {
           const showResult = await this.repository.show(parentChange.changeId);
@@ -759,37 +798,31 @@ export class RepositorySourceControlManager {
       const parentShowResultsArray = await Promise.all(parentShowPromises);
 
       for (const { changeId, showResult } of parentShowResultsArray) {
-        newParentShowResults.set(changeId, showResult);
-        newFileStatusesByChange.set(changeId, showResult.fileStatuses);
-        newConflictedFilesByChange.set(changeId, showResult.conflictedFiles);
+        parentShowResults.set(changeId, showResult);
+        fileStatusesByChange.set(changeId, showResult.fileStatuses);
+        conflictedFilesByChange.set(changeId, showResult.conflictedFiles);
       }
     }
 
     // Base comparison: fetch diff from base revision to the additive target.
     // This runs after parent show() completes because getBaseComparisonTarget
     // needs parentShowResults to determine @-- (the parent's parent).
-    const newBaseComparisonResults = new Map<
-      string,
-      { fileStatuses: FileStatus[]; toRevision: string; error?: string }
-    >();
+    let baseComparisonResult: BaseComparisonResult | undefined;
 
-    if (showBaseComparison) {
+    if (config.showBaseComparison) {
       const toRevision = RepositorySourceControlManager.getBaseComparisonTarget(
         status,
-        newParentShowResults,
-        showParentCommit,
+        parentShowResults,
+        config.showParentCommit,
       );
 
       if (toRevision !== null) {
         try {
           const fileStatuses = await this.repository.diffSummary(
-            baseRevision,
+            config.baseRevision,
             toRevision,
           );
-          newBaseComparisonResults.set("base-comparison", {
-            fileStatuses,
-            toRevision,
-          });
+          baseComparisonResult = { kind: "ok", fileStatuses, toRevision };
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e);
           // Parse jj's "error: <detail>" stderr format; falls back to a
@@ -797,13 +830,13 @@ export class RepositorySourceControlManager {
           const shortMessage =
             message.match(/error:\s*([\s\S]+?)(?:\n|$)/i)?.[1] ??
             message.substring(0, 80);
-          newBaseComparisonResults.set("base-comparison", {
-            fileStatuses: [],
+          baseComparisonResult = {
+            kind: "error",
             toRevision,
             error: shortMessage,
-          });
+          };
           logger.warn(
-            `Base comparison failed for revset "${baseRevision}": ${message}`,
+            `Base comparison failed for revset "${config.baseRevision}": ${message}`,
           );
         }
       }
@@ -813,18 +846,21 @@ export class RepositorySourceControlManager {
     // can show A/M/D badges. The key is the toRevision (the revision used in
     // the resourceUri), which matches how provideFileDecoration extracts the
     // rev from jj:// URIs.
-    for (const [, result] of newBaseComparisonResults) {
-      if (!result.error) {
-        newFileStatusesByChange.set(result.toRevision, result.fileStatuses);
-      }
+    if (baseComparisonResult?.kind === "ok") {
+      fileStatusesByChange.set(
+        baseComparisonResult.toRevision,
+        baseComparisonResult.fileStatuses,
+      );
     }
 
-    this.status = status;
-    this.fileStatusesByChange = newFileStatusesByChange;
-    this.conflictedFilesByChange = newConflictedFilesByChange;
-    this.parentShowResults = newParentShowResults;
-    this.baseComparisonResults = newBaseComparisonResults;
-    this.trackedFiles = newTrackedFiles;
+    return {
+      status,
+      fileStatusesByChange,
+      conflictedFilesByChange,
+      parentShowResults,
+      baseComparisonResult,
+      trackedFiles,
+    };
   }
 
   static getLabel(prefix: string, change: Change) {
@@ -835,191 +871,139 @@ export class RepositorySourceControlManager {
     }${change.description ? "" : " (no description)"}`;
   }
 
-  render() {
-    if (!this.status?.workingCopy) {
+  render(config: RefreshConfig) {
+    const snapshot = this.snapshot;
+    if (!snapshot?.status.workingCopy) {
       throw new Error(
         "Cannot render source control without a current working copy change.",
       );
     }
 
-    this.workingCopyResourceGroup.label =
-      RepositorySourceControlManager.getLabel(
-        "Working Copy",
-        this.status.workingCopy,
-      );
-    this.workingCopyResourceGroup.resourceStates = this.status.fileStatuses.map(
-      (fileStatus) => {
-        return {
-          resourceUri: vscode.Uri.file(fileStatus.path),
-          decorations: {
-            strikeThrough: fileStatus.type === "D",
-            tooltip: path.basename(fileStatus.file),
-          },
-          command: getResourceStateCommand(
-            fileStatus,
-            toJJUri(vscode.Uri.file(`${fileStatus.path}`), {
-              diffOriginalRev: "@",
-            }),
-            vscode.Uri.file(fileStatus.path),
-            "(Working Copy)",
-          ),
-        };
-      },
-    );
-    this.sourceControl.count = this.status.fileStatuses.length;
-
-    const config = vscode.workspace.getConfiguration(
-      "jjk",
-      vscode.Uri.file(this.repositoryRoot),
-    );
-    const showParentCommit =
-      config.get<boolean>("showParentCommit") ?? true;
-    const showBaseComparison =
-      config.get<boolean>("showBaseComparison") ?? false;
-    const baseRevision =
-      config.get<string>("baseRevision") ?? "trunk()";
-
-    this.renderParentCommits(this.status, showParentCommit);
-
-    this.renderBaseComparison(showBaseComparison, baseRevision);
+    this.renderWorkingCopy(snapshot);
+    this.renderParentGroups(snapshot, config);
+    this.renderBaseComparisonGroup(snapshot, config);
 
     this.decorationProvider.onRefresh(
       this.repositoryRoot,
-      this.fileStatusesByChange,
-      this.trackedFiles,
-      this.conflictedFilesByChange,
+      snapshot.fileStatusesByChange,
+      snapshot.trackedFiles,
+      snapshot.conflictedFilesByChange,
     );
   }
 
-  private renderParentCommits(
-    status: RepositoryStatus,
-    showParentCommit: boolean,
-  ) {
-    if (!showParentCommit) {
-      for (const group of this.parentResourceGroups) {
-        group.dispose();
-      }
-      this.parentResourceGroups = [];
-      return;
-    }
-
-    const updatedGroups: vscode.SourceControlResourceGroup[] = [];
-    for (const group of this.parentResourceGroups) {
-      const parentChange = status.parentChanges.find(
-        (change) => change.changeId === group.id,
+  private renderWorkingCopy(snapshot: RepoSnapshot) {
+    this.workingCopyResourceGroup.label =
+      RepositorySourceControlManager.getLabel(
+        "Working Copy",
+        snapshot.status.workingCopy,
       );
-      if (!parentChange) {
-        group.dispose();
-      } else {
-        group.label = RepositorySourceControlManager.getLabel(
-          "Parent Commit",
-          parentChange,
-        );
-        updatedGroups.push(group);
-      }
-    }
-    this.parentResourceGroups = updatedGroups;
-
-    for (const parentChange of this.status!.parentChanges) {
-      let parentChangeResourceGroup!: vscode.SourceControlResourceGroup;
-
-      const parentGroup = this.parentResourceGroups.find(
-        (group) => group.id === parentChange.changeId,
+    this.workingCopyResourceGroup.resourceStates =
+      snapshot.status.fileStatuses.map((fileStatus) =>
+        toResourceState(
+          fileStatus,
+          toJJUri(vscode.Uri.file(fileStatus.path), { diffOriginalRev: "@" }),
+          vscode.Uri.file(fileStatus.path),
+          "(Working Copy)",
+        ),
       );
-      if (!parentGroup) {
-        parentChangeResourceGroup = this.sourceControl.createResourceGroup(
-          parentChange.changeId,
-          RepositorySourceControlManager.getLabel(
-            "Parent Commit",
-            parentChange,
-          ),
-        );
-        this.parentResourceGroups.push(parentChangeResourceGroup);
-      } else {
-        parentChangeResourceGroup = parentGroup;
-      }
-
-      const showResult = this.parentShowResults.get(parentChange.changeId);
-      if (showResult) {
-        parentChangeResourceGroup.resourceStates =
-          showResult.fileStatuses.map((parentStatus) => {
-            return {
-              resourceUri: toJJUri(vscode.Uri.file(parentStatus.path), {
-                rev: parentChange.changeId,
-              }),
-              decorations: {
-                strikeThrough: parentStatus.type === "D",
-                tooltip: path.basename(parentStatus.file),
-              },
-              command: getResourceStateCommand(
-                parentStatus,
-                toJJUri(vscode.Uri.file(parentStatus.path), {
-                  diffOriginalRev: parentChange.changeId,
-                }),
-                toJJUri(vscode.Uri.file(parentStatus.path), {
-                  rev: parentChange.changeId,
-                }),
-                `(${parentChange.changeId})`,
-              ),
-            };
-          });
-      }
-    }
+    this.sourceControl.count = snapshot.status.fileStatuses.length;
   }
 
-  private renderBaseComparison(
-    showBaseComparison: boolean,
-    baseRevision: string,
-  ) {
-    this.baseComparisonGroups = reconcileGroups(
-      this.baseComparisonGroups,
-      new Set(this.baseComparisonResults.keys()),
+  private renderParentGroups(snapshot: RepoSnapshot, config: RefreshConfig) {
+    const validParentIds = new Set(
+      config.showParentCommit
+        ? snapshot.status.parentChanges.map((c) => c.changeId)
+        : [],
+    );
+    this.parentResourceGroups = reconcileGroups(
+      this.parentResourceGroups,
+      validParentIds,
     );
 
-    if (!showBaseComparison) {
-      for (const group of this.baseComparisonGroups) {
-        group.dispose();
-      }
-      this.baseComparisonGroups = [];
-      return;
-    }
-
-    for (const [groupId, result] of this.baseComparisonResults) {
-      let group = this.baseComparisonGroups.find((g) => g.id === groupId);
-      if (!group) {
-        // New group - create now, fill details in below
-        group = this.sourceControl.createResourceGroup(groupId, "");
-        this.baseComparisonGroups.push(group);
-      }
-
-      if (result.error) {
-        group.label = `Changes since ${baseRevision} (error: ${result.error})`;
-        group.resourceStates = [];
+    for (const parentChange of snapshot.status.parentChanges) {
+      if (!validParentIds.has(parentChange.changeId)) {
         continue;
       }
 
-      group.label = `Changes since ${baseRevision}`;
-      group.resourceStates = result.fileStatuses.map((fileStatus) => {
-        const leftUri = toJJUri(vscode.Uri.file(fileStatus.path), {
-          rev: baseRevision,
-        });
-        const rightUri = toJJUri(vscode.Uri.file(fileStatus.path), {
-          rev: result.toRevision,
-        });
-        return {
-          resourceUri: rightUri,
-          decorations: {
-            strikeThrough: fileStatus.type === "D",
-            tooltip: path.basename(fileStatus.file),
-          },
-          command: getResourceStateCommand(
-            fileStatus,
-            leftUri,
-            rightUri,
-            `(${baseRevision})`,
+      let group = this.parentResourceGroups.find(
+        (g) => g.id === parentChange.changeId,
+      );
+      if (!group) {
+        group = this.sourceControl.createResourceGroup(
+          parentChange.changeId,
+          "",
+        );
+        this.parentResourceGroups.push(group);
+      }
+
+      group.label = RepositorySourceControlManager.getLabel(
+        "Parent Commit",
+        parentChange,
+      );
+
+      const showResult = snapshot.parentShowResults.get(parentChange.changeId);
+      if (showResult) {
+        group.resourceStates = showResult.fileStatuses.map((parentStatus) =>
+          toResourceState(
+            parentStatus,
+            toJJUri(vscode.Uri.file(parentStatus.path), {
+              diffOriginalRev: parentChange.changeId,
+            }),
+            toJJUri(vscode.Uri.file(parentStatus.path), {
+              rev: parentChange.changeId,
+            }),
+            `(${parentChange.changeId})`,
           ),
-        };
-      });
+        );
+      }
+    }
+  }
+
+  private renderBaseComparisonGroup(
+    snapshot: RepoSnapshot,
+    config: RefreshConfig,
+  ) {
+    const validBaseIds = new Set(
+      snapshot.baseComparisonResult ? ["base-comparison"] : [],
+    );
+    this.baseComparisonGroups = reconcileGroups(
+      this.baseComparisonGroups,
+      validBaseIds,
+    );
+
+    if (!config.showBaseComparison || !snapshot.baseComparisonResult) {
+      return;
+    }
+
+    let group = this.baseComparisonGroups.find(
+      (g) => g.id === "base-comparison",
+    );
+    if (!group) {
+      group = this.sourceControl.createResourceGroup("base-comparison", "");
+      this.baseComparisonGroups.push(group);
+    }
+
+    const result = snapshot.baseComparisonResult;
+    switch (result.kind) {
+      case "error":
+        group.label = `Changes since ${config.baseRevision} (error: ${result.error})`;
+        group.resourceStates = [];
+        break;
+      case "ok":
+        group.label = `Changes since ${config.baseRevision}`;
+        group.resourceStates = result.fileStatuses.map((fileStatus) =>
+          toResourceState(
+            fileStatus,
+            toJJUri(vscode.Uri.file(fileStatus.path), {
+              rev: config.baseRevision,
+            }),
+            toJJUri(vscode.Uri.file(fileStatus.path), {
+              rev: result.toRevision,
+            }),
+            `(${config.baseRevision})`,
+          ),
+        );
+        break;
     }
   }
 
@@ -1036,22 +1020,25 @@ export class RepositorySourceControlManager {
   }
 }
 
-/**
- * Dispose resource groups whose IDs are no longer valid and return the rest.
- */
-function reconcileGroups(
-  groups: vscode.SourceControlResourceGroup[],
-  validIds: Set<string>,
-): vscode.SourceControlResourceGroup[] {
-  const kept: vscode.SourceControlResourceGroup[] = [];
-  for (const group of groups) {
-    if (validIds.has(group.id)) {
-      kept.push(group);
-    } else {
-      group.dispose();
-    }
-  }
-  return kept;
+function toResourceState(
+  fileStatus: FileStatus,
+  beforeUri: vscode.Uri,
+  afterUri: vscode.Uri,
+  diffTitleSuffix: string,
+): vscode.SourceControlResourceState {
+  return {
+    resourceUri: afterUri,
+    decorations: {
+      strikeThrough: fileStatus.type === "D",
+      tooltip: path.basename(fileStatus.file),
+    },
+    command: getResourceStateCommand(
+      fileStatus,
+      beforeUri,
+      afterUri,
+      diffTitleSuffix,
+    ),
+  };
 }
 
 function getResourceStateCommand(
@@ -1568,7 +1555,8 @@ export class JJRepository {
         return [];
       }
       return output.split("\n").filter(Boolean);
-    } catch {
+    } catch (e) {
+      logger.warn(`Failed to list bookmarks: ${String(e)}`);
       return [];
     }
   }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1540,6 +1540,39 @@ export class JJRepository {
     return fileStatuses;
   }
 
+  /**
+   * Returns local bookmark names that are ancestors of @, suitable as base
+   * revision presets.
+   */
+  async bookmarksOfAncestors(): Promise<string[]> {
+    try {
+      const output = (
+        await handleJJCommand(
+          this.spawnJJRead(
+            [
+              "log",
+              "--no-graph",
+              "-r",
+              "bookmarks() & ::@",
+              "-T",
+              'local_bookmarks.join("\\n") ++ "\\n"',
+            ],
+            { defaultTimeout: 5000 },
+          ),
+        )
+      )
+        .toString()
+        .trim();
+
+      if (!output) {
+        return [];
+      }
+      return output.split("\n").filter(Boolean);
+    } catch {
+      return [];
+    }
+  }
+
   async describeRetryImmutable(rev: string, message: string) {
     try {
       return await this.describe(rev, message);

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -688,19 +688,27 @@ export class RepositorySourceControlManager {
       }
     }
 
-    const parentShowPromises = status.parentChanges.map(
-      async (parentChange) => {
-        const showResult = await this.repository.show(parentChange.changeId);
-        return { changeId: parentChange.changeId, showResult };
-      },
+    const config = vscode.workspace.getConfiguration(
+      "jjk",
+      vscode.Uri.file(this.repositoryRoot),
     );
+    const showParentCommit = config.get<boolean>("showParentCommit") ?? true;
 
-    const parentShowResultsArray = await Promise.all(parentShowPromises);
+    if (showParentCommit) {
+      const parentShowPromises = status.parentChanges.map(
+        async (parentChange) => {
+          const showResult = await this.repository.show(parentChange.changeId);
+          return { changeId: parentChange.changeId, showResult };
+        },
+      );
 
-    for (const { changeId, showResult } of parentShowResultsArray) {
-      newParentShowResults.set(changeId, showResult);
-      newFileStatusesByChange.set(changeId, showResult.fileStatuses);
-      newConflictedFilesByChange.set(changeId, showResult.conflictedFiles);
+      const parentShowResultsArray = await Promise.all(parentShowPromises);
+
+      for (const { changeId, showResult } of parentShowResultsArray) {
+        newParentShowResults.set(changeId, showResult);
+        newFileStatusesByChange.set(changeId, showResult.fileStatuses);
+        newConflictedFilesByChange.set(changeId, showResult.conflictedFiles);
+      }
     }
 
     this.status = status;
@@ -751,9 +759,33 @@ export class RepositorySourceControlManager {
     );
     this.sourceControl.count = this.status.fileStatuses.length;
 
+    this.renderParentCommits(this.status);
+
+    this.decorationProvider.onRefresh(
+      this.repositoryRoot,
+      this.fileStatusesByChange,
+      this.trackedFiles,
+      this.conflictedFilesByChange,
+    );
+  }
+
+  private renderParentCommits(status: RepositoryStatus) {
+    const config = vscode.workspace.getConfiguration(
+      "jjk",
+      vscode.Uri.file(this.repositoryRoot),
+    );
+
+    if (!config.get<boolean>("showParentCommit", true)) {
+      for (const group of this.parentResourceGroups) {
+        group.dispose();
+      }
+      this.parentResourceGroups = [];
+      return;
+    }
+
     const updatedGroups: vscode.SourceControlResourceGroup[] = [];
     for (const group of this.parentResourceGroups) {
-      const parentChange = this.status.parentChanges.find(
+      const parentChange = status.parentChanges.find(
         (change) => change.changeId === group.id,
       );
       if (!parentChange) {
@@ -768,7 +800,7 @@ export class RepositorySourceControlManager {
     }
     this.parentResourceGroups = updatedGroups;
 
-    for (const parentChange of this.status.parentChanges) {
+    for (const parentChange of this.status!.parentChanges) {
       let parentChangeResourceGroup!: vscode.SourceControlResourceGroup;
 
       const parentGroup = this.parentResourceGroups.find(
@@ -789,8 +821,8 @@ export class RepositorySourceControlManager {
 
       const showResult = this.parentShowResults.get(parentChange.changeId);
       if (showResult) {
-        parentChangeResourceGroup.resourceStates = showResult.fileStatuses.map(
-          (parentStatus) => {
+        parentChangeResourceGroup.resourceStates =
+          showResult.fileStatuses.map((parentStatus) => {
             return {
               resourceUri: toJJUri(vscode.Uri.file(parentStatus.path), {
                 rev: parentChange.changeId,
@@ -810,17 +842,9 @@ export class RepositorySourceControlManager {
                 `(${parentChange.changeId})`,
               ),
             };
-          },
-        );
+          });
       }
     }
-
-    this.decorationProvider.onRefresh(
-      this.repositoryRoot,
-      this.fileStatusesByChange,
-      this.trackedFiles,
-      this.conflictedFilesByChange,
-    );
   }
 
   dispose() {

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1,5 +1,7 @@
 import * as assert from "assert";
+import * as path from "path";
 import { getExtensionAPI } from "./extensionApi";
+import type { FileStatus } from "../repository";
 
 suite("parseRenamePaths", () => {
   let parseRenamePaths: (
@@ -106,5 +108,80 @@ suite("parseRenamePaths", () => {
   test("should return null for empty input", () => {
     const input = "";
     assert.strictEqual(parseRenamePaths(input), null);
+  });
+});
+
+suite("parseFileStatusLine", () => {
+  let parseFileStatusLine: (
+    repositoryRoot: string,
+    line: string,
+    out: FileStatus[],
+  ) => boolean;
+
+  const root = "/repo";
+
+  suiteSetup(async () => {
+    ({ parseFileStatusLine } = (await getExtensionAPI()).repository);
+  });
+
+  test("parses added file", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(parseFileStatusLine(root, "A src/new.ts", out), true);
+    assert.deepStrictEqual(out, [
+      { type: "A", file: "src/new.ts", path: path.join(root, "src/new.ts") },
+    ]);
+  });
+
+  test("parses modified file", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "M lib/utils.ts", out);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].type, "M");
+    assert.strictEqual(out[0].file, "lib/utils.ts");
+  });
+
+  test("parses deleted file", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "D old-file.txt", out);
+    assert.strictEqual(out[0].type, "D");
+  });
+
+  test("parses rename with brace syntax", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "R src/{old => new}/file.ts", out);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(out[0].type, "R");
+    assert.strictEqual(out[0].file, "src/new/file.ts");
+    assert.strictEqual(out[0].renamedFrom, "src/old/file.ts");
+  });
+
+  test("parses copy", () => {
+    const out: FileStatus[] = [];
+    parseFileStatusLine(root, "C src/{a => b}.ts", out);
+    assert.strictEqual(out[0].type, "C");
+    assert.strictEqual(out[0].renamedFrom, "src/a.ts");
+  });
+
+  test("returns false for non-matching line", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(
+      parseFileStatusLine(root, "Working copy : abc123", out),
+      false,
+    );
+    assert.strictEqual(out.length, 0);
+  });
+
+  test("returns false for empty line", () => {
+    const out: FileStatus[] = [];
+    assert.strictEqual(parseFileStatusLine(root, "", out), false);
+  });
+
+  test("appends to existing array", () => {
+    const out: FileStatus[] = [
+      { type: "A", file: "existing.ts", path: path.join(root, "existing.ts") },
+    ];
+    parseFileStatusLine(root, "M second.ts", out);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[1].type, "M");
   });
 });

--- a/src/test/repository.test.ts
+++ b/src/test/repository.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as path from "path";
 import { getExtensionAPI } from "./extensionApi";
-import type { FileStatus } from "../repository";
+import type { FileStatus, RepositoryStatus, Show } from "../repository";
 
 suite("parseRenamePaths", () => {
   let parseRenamePaths: (
@@ -183,5 +183,129 @@ suite("parseFileStatusLine", () => {
     parseFileStatusLine(root, "M second.ts", out);
     assert.strictEqual(out.length, 2);
     assert.strictEqual(out[1].type, "M");
+  });
+});
+
+suite("getBaseComparisonTarget", () => {
+  let getBaseComparisonTarget: (
+    status: RepositoryStatus,
+    parentShowResults: Map<string, Show>,
+    showParentCommit: boolean,
+  ) => string | null;
+
+  suiteSetup(async () => {
+    const api = await getExtensionAPI();
+    const cls = api.repository.RepositorySourceControlManager;
+    getBaseComparisonTarget = (status, parentShowResults, showParentCommit) =>
+      cls.getBaseComparisonTarget(status, parentShowResults, showParentCommit);
+  });
+
+  function makeChange(changeId: string): RepositoryStatus["parentChanges"][0] {
+    return {
+      changeId,
+      commitId: `commit-${changeId}`,
+      description: "",
+      isEmpty: false,
+      isConflict: false,
+    };
+  }
+
+  function makeStatus(
+    changeId: string,
+    parentChangeIds: string[],
+  ): RepositoryStatus {
+    return {
+      fileStatuses: [],
+      workingCopy: makeChange(changeId),
+      parentChanges: parentChangeIds.map(makeChange),
+      conflictedFiles: new Set(),
+    };
+  }
+
+  function makeShow(changeId: string, parentChangeIds: string[]): Show {
+    return {
+      change: {
+        ...makeChange(changeId),
+        author: { name: "someone", email: "someone@somewhere.com" },
+        authoredDate: "sometime",
+        parentChangeIds,
+        parentCommitIds: parentChangeIds.map((id) => `commit-${id}`),
+      },
+      fileStatuses: [],
+      conflictedFiles: new Set(),
+    };
+  }
+
+  test("linear shows base comparison", () => {
+    const grandparent = makeChange("grandparent");
+    const parent = makeChange("parent");
+    const child = makeChange("child");
+    const status = makeStatus(child.changeId, [parent.changeId]);
+
+    const parentShow = makeShow(parent.changeId, [grandparent.changeId]);
+    const parentShowResults = new Map<string, Show>([
+      [parent.changeId, parentShow],
+    ]);
+
+    let shown = getBaseComparisonTarget(status, parentShowResults, true);
+    assert.strictEqual(grandparent.changeId, shown);
+    shown = getBaseComparisonTarget(status, parentShowResults, false);
+    assert.strictEqual(parent.changeId, shown);
+  });
+
+  test("multiple parents, no base comparison", () => {
+    const grandparent1 = makeChange("grandparent1");
+    const parent1 = makeChange("parent1");
+    const grandparent2 = makeChange("grandparent2");
+    const parent2 = makeChange("parent2");
+    const child = makeChange("child");
+    const status = makeStatus(child.changeId, [
+      parent1.changeId,
+      parent2.changeId,
+    ]);
+
+    const parent1Show = makeShow(parent1.changeId, [grandparent1.changeId]);
+    const parent2Show = makeShow(parent2.changeId, [grandparent2.changeId]);
+    const parentShowResults = new Map<string, Show>([
+      [parent1.changeId, parent1Show],
+      [parent2.changeId, parent2Show],
+    ]);
+
+    let shown = getBaseComparisonTarget(status, parentShowResults, true);
+    assert.strictEqual(null, shown);
+    shown = getBaseComparisonTarget(status, parentShowResults, false);
+    assert.strictEqual(null, shown);
+  });
+
+  test("single parent, multiple grandparents", () => {
+    const grandparent1 = makeChange("grandparent1");
+    const grandparent2 = makeChange("grandparent2");
+    const parent = makeChange("parent");
+    const child = makeChange("child");
+    const status = makeStatus(child.changeId, [parent.changeId]);
+
+    const parentShow = makeShow(parent.changeId, [
+      grandparent1.changeId,
+      grandparent2.changeId,
+    ]);
+    const parentShowResults = new Map<string, Show>([
+      [parent.changeId, parentShow],
+    ]);
+
+    // If we're showing the parent, then base target is unclear - there are two
+    // grandparents
+    let shown = getBaseComparisonTarget(status, parentShowResults, true);
+    assert.strictEqual(null, shown);
+
+    // If we're not showing the parent, then base target is clear - its parent
+    shown = getBaseComparisonTarget(status, parentShowResults, false);
+    assert.strictEqual(parent.changeId, shown);
+  });
+
+  test("missing show result", () => {
+    const status = makeStatus("child", ["parent"]);
+    const parentShowResults = new Map<string, Show>();
+    const shown = getBaseComparisonTarget(status, parentShowResults, true);
+    assert.strictEqual(null, shown);
   });
 });

--- a/src/test/scm.test.ts
+++ b/src/test/scm.test.ts
@@ -83,7 +83,8 @@ suite("SCM Integration Tests", () => {
     );
 
     // Record the current working copy change ID
-    const workingCopyChangeIdBefore = repoSCM.status?.workingCopy.changeId;
+    const workingCopyChangeIdBefore =
+      repoSCM.snapshot?.status.workingCopy?.changeId;
     assert.ok(workingCopyChangeIdBefore, "Expected a working copy change ID");
 
     // Execute jj.new via the source control.
@@ -103,7 +104,8 @@ suite("SCM Integration Tests", () => {
     );
 
     // Verify the working copy change ID has changed
-    const workingCopyChangeIdAfter = repoSCM.status?.workingCopy.changeId;
+    const workingCopyChangeIdAfter =
+      repoSCM.snapshot?.status.workingCopy?.changeId;
     assert.ok(
       workingCopyChangeIdAfter,
       "Expected a working copy change ID after jj.new",

--- a/src/test/scm.test.ts
+++ b/src/test/scm.test.ts
@@ -73,8 +73,7 @@ suite("SCM Integration Tests", () => {
     await vscode.commands.executeCommand("jj.refresh");
 
     // Verify the file shows up in the working copy resource group
-    const workingCopyStates =
-      repoSCM.workingCopyResourceGroup.resourceStates;
+    const workingCopyStates = repoSCM.workingCopyResourceGroup.resourceStates;
     const addedFile = workingCopyStates.find((state) =>
       state.resourceUri.fsPath.endsWith(testFileName),
     );


### PR DESCRIPTION
Third and final PR in the stack (depends on #252 ). This is the main feature: a (default-off) **Base Comparison** resource group that shows cumulative changes from a configurable base revision (default: `trunk()`) to the current branch position. This gives a "PR diff" view directly in the SCM sidebar.

## Summary

The display follows an **additive model** so the three groups partition changes without overlap:
- **Base Comparison**: base (default `trunk()`) → `@--` (or `@-` when parent is hidden)
- **Parent Commit**: `@--` → `@-`
- **Working Copy**: `@-` → `@`

Merge commits suppress the base comparison, since it's unclear which diffs to show beyond each parent... and I figured that's not the worst thing, if there's multiple parents, there's already multiple resource groups, so you don't need a base comparison.

## UX Choices

In building this feature, there were a few UX choices made; curious to hear your thoughts!

### Separate `parent` and `base` resource groups

The groups partition changes so they don't overlap: base→@--, @--→@-, @-→@. The reasoning:
- Default behavior is unchanged — working copy and parent commit are what `jj status` shows, and that's what most users expect from a VCS sidebar
- The base comparison is opt-in and additive, so it doesn't disrupt the existing experience
- It gives the user options at different granularities: working copy (what I'm editing now), parent commit (what I just committed), and base comparison (the full branch diff). Each tells a different story, and you might not always want all of them — parent commit may be clear and simple while `trunk()` is far away or irrelevant

That said, there are other possibilities here - e.g. like having 'working copy' and 'configurable base' (defaulting to parent commit, but could be `trunk()`); that would be a simpler UX.

### Default to `parent`
`showBaseComparison` defaults to `false` to keep the out-of-box experience unchanged — staging area and last commit, same as today.

### Merge commit suppression

When `@` has multiple parents, the base comparison group is hidden. With multiple parents there are already multiple resource groups shown, and it's not clear what the "right" base comparison would be. This could be revisited.

### QuickPick bookmark list

The "Change base revision" QuickPick currently shows bookmarks matching `bookmarks() & ::@` — all bookmarks that are ancestors of `@`, not just bookmarks between the current base and head. This is broader than strictly necessary (it includes `main` itself, for instance), but it gives a useful set of landmark points you might want to diff against. Could be tightened to e.g. `bookmarks() & trunk()::@` if the broader set turns out to be noisy, or broadened to `bookmarks()`, or be configurable...

## New settings

| Setting | Default | Description |
|---|---|---|
| `jjk.showBaseComparison` | `false` | Toggle base comparison resource group |
| `jjk.baseRevision` | `"trunk()"` | Revset expression for the comparison base |

### New command

- **Change base revision** (`jj.changeBaseRevision`) — QuickPick offering `trunk()`, bookmarks between base and head, and custom revset input. Appears on base comparison groups and in the SCM title bar when base comparison is enabled.

### Implementation details

- Reuses `parseFileStatusLine` (from PR 1) to parse `jj diff --summary` output
- `bookmarksOfAncestors()` finds bookmarks in the revset range for the QuickPick
- `getBaseComparisonTarget()` static method computes the correct base target given the additive model, handling linear chains, merges, and hidden parents
- `BaseComparisonResult` discriminated union (`kind: "ok" | "error"`) replaces a looser Map for the base comparison state
- `RefreshConfig` reads all settings once per refresh cycle instead of inline reads scattered through `render()`
- Config change listener triggers refresh when `baseRevision`, `showBaseComparison`, or `showParentCommit` change
- VS Code context keys (`jj.commitGroupIds`, `jj.baseComparisonGroupIds`) power when-clauses for the "Change base revision" button

## Context

:wave: I'm a new contributor — also new to TypeScript and VS Code extensions. I used AI fairly substantially in writing this, but did my best to understand the code and be responsible for it.

The goal was to see a cumulative diff for a whole branch (like a PR diff) without leaving the editor. I split the work into three PRs to keep each one reviewable: PR 1 is a small refactor + tests, PR 2 adds the `showParentCommit` toggle, and this PR adds the actual base comparison feature.

## Test plan

- [x] Unit tests for `getBaseComparisonTarget` (linear history, merge at @, merge at @-, missing show result)
- [x] Manual: enable `jjk.showBaseComparison` → base comparison group appears with files changed since `trunk()`
- [x] Manual: use "Change base revision" command → QuickPick shows trunk(), bookmarks, custom input
- [x] Manual: merge commits → base comparison group hidden
- [x] Manual: toggle `showParentCommit` off → additive model adjusts (base comparison goes to `@-` instead of `@--`)
- [x] Existing tests still pass