### PR TITLE
Refine graph layout and readability

### DIFF
--- a/src/webview/graph.css
+++ b/src/webview/graph.css
@@ -171,13 +171,19 @@ body {
 /* Transition effects */
 .node-circle circle,
 .connection-line {
-  transition: opacity 0.2s ease-in-out;
+  transition:
+    opacity 0.2s ease-in-out,
+    stroke-width 0.2s ease-in-out,
+    stroke 0.2s ease-in-out;
 }
 
 .connection-line {
   stroke: var(--vscode-charts-blue);
   stroke-width: 2;
   fill: none;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  opacity: 0.68;
 }
 
 /* Node styling */
@@ -221,19 +227,26 @@ body {
 }
 
 .connection-line.dimmed {
-  opacity: 0.4;
+  opacity: 0.16;
+  stroke-width: 1.6;
 }
 
 .connection-line.highlighted {
-  opacity: 0.95;
+  opacity: 1;
+  stroke-width: 3;
+  stroke: color-mix(
+    in srgb,
+    var(--vscode-charts-blue) 72%,
+    white 28%
+  );
 }
 
 /* Child connection styling */
 .connection-line.highlighted.child-connection {
   stroke: color-mix(
     in srgb,
-    var(--vscode-charts-blue) 82%,
-    var(--vscode-terminal-ansiGreen) 18%
+    var(--vscode-charts-blue) 60%,
+    var(--vscode-terminal-ansiGreen) 40%
   );
 }
 
@@ -269,7 +282,7 @@ body {
   flex: 1;
   min-width: 0;
   margin-left: var(--graph-width, 0px);
-  padding-left: 8px;
+  padding-left: 4px;
   gap: 1px;
 }
 

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -25,8 +25,9 @@
       // Rich per-row state lives in JS rather than serialized DOM attributes. The map is rebuilt on
       // every `updateGraph()` call, so it never outlives the current render.
       const rowDataByChangeId = new Map();
-      const graphLaneStep = 10;
+      const graphLaneStep = 6;
       const graphLanePadding = 6;
+      const branchCornerRadius = 8;
       const hoverCard = document.getElementById("hover-card");
       let hoveredNode = null;
       let hoverHideTimer = null;
@@ -382,6 +383,118 @@
         );
       }
 
+      function getSymbolRadius(node) {
+        return node.dataset.changeId === currentWorkingCopyId ? 7 : 5;
+      }
+
+      function getRoundedConnectionGeometry(
+        currentX,
+        currentExitY,
+        parentX,
+        parentEntryY,
+      ) {
+        const dx = parentX - currentX;
+        const dy = parentEntryY - currentExitY;
+        if (Math.abs(dx) < 0.001 || dy <= 0) {
+          return null;
+        }
+
+        const laneSpan = Math.abs(dx) / graphLaneStep;
+        const diagonalRise = Math.max(
+          0,
+          Math.min(
+            laneSpan * graphLaneStep * 1.25,
+            dy - 2,
+          ),
+        );
+        const radius = Math.max(
+          0,
+          Math.min(
+            branchCornerRadius,
+            Math.abs(dx) / 2 - 0.5,
+          ),
+        );
+
+        if (radius <= 0 || diagonalRise <= 0) {
+          return null;
+        }
+
+        const straightRise = dy - diagonalRise;
+        const startCornerY = currentExitY + straightRise / 2;
+        const endCornerY = parentEntryY - straightRise / 2;
+        const diagonalLength = Math.hypot(dx, diagonalRise);
+        const diagonalUnitX = dx / diagonalLength;
+        const diagonalUnitY = diagonalRise / diagonalLength;
+        const diagonalTurnAngle = Math.atan2(Math.abs(dx), diagonalRise);
+        const tangentOffset = Math.max(
+          0,
+          Math.min(
+            radius * Math.tan(diagonalTurnAngle / 2),
+            straightRise / 2 - 0.5,
+            diagonalLength / 2 - 0.5,
+          ),
+        );
+
+        if (tangentOffset <= 0) {
+          return null;
+        }
+
+        const startVerticalEndY = startCornerY - tangentOffset;
+        const startDiagonalX = currentX + diagonalUnitX * tangentOffset;
+        const startDiagonalY = startCornerY + diagonalUnitY * tangentOffset;
+        const endDiagonalX = parentX - diagonalUnitX * tangentOffset;
+        const endDiagonalY = endCornerY - diagonalUnitY * tangentOffset;
+        const endVerticalStartY = endCornerY + tangentOffset;
+
+        return {
+          startVerticalEndY,
+          startCornerY,
+          startDiagonalX,
+          startDiagonalY,
+          endDiagonalX,
+          endDiagonalY,
+          endCornerY,
+          endVerticalStartY,
+        };
+      }
+
+      function buildRoundedConnectionPath(
+        currentX,
+        currentExitY,
+        parentX,
+        parentEntryY,
+        geometry,
+      ) {
+        if (!geometry) {
+          return `
+            M ${currentX} ${currentExitY}
+            L ${parentX} ${parentEntryY}
+          `;
+        }
+
+        const {
+          startVerticalEndY,
+          startCornerY,
+          startDiagonalX,
+          startDiagonalY,
+          endDiagonalX,
+          endDiagonalY,
+          endCornerY,
+          endVerticalStartY,
+        } = geometry;
+
+        return `
+          M ${currentX} ${currentExitY}
+          L ${currentX} ${startVerticalEndY}
+          Q ${currentX} ${startCornerY}
+            ${startDiagonalX} ${startDiagonalY}
+          L ${endDiagonalX} ${endDiagonalY}
+          Q ${parentX} ${endCornerY}
+            ${parentX} ${endVerticalStartY}
+          L ${parentX} ${parentEntryY}
+        `;
+      }
+
       function getRowData(changeId) {
         return rowDataByChangeId.get(changeId);
       }
@@ -634,7 +747,7 @@
       }
 
       function updateConnections() {
-        const nodes = document.querySelectorAll(".change-node");
+        const nodes = Array.from(document.querySelectorAll(".change-node"));
 
         const connectionLines = document.getElementById("connection-lines");
         connectionLines.innerHTML = "";
@@ -644,17 +757,21 @@
         const svgRect = svg.getBoundingClientRect();
 
         const nodeMap = new Map();
-        nodes.forEach((node, i) => {
+        nodes.forEach((node) => {
           nodeMap.set(node.dataset.changeId, node);
         });
 
-        nodes.forEach((node, index) => {
+        const edgeSpecs = [];
+
+        nodes.forEach((node) => {
           const parentIds = getParentIds(node);
           const { nodeRect, y: currentY } = getNodeCenter(node, svgRect);
           const currentColumn = Number(node.dataset.symbolColumn || "0");
+          const currentRadius = getSymbolRadius(node);
 
           // Convert to SVG coordinates with vertical centering
           const currentX = getLaneX(nodeRect, svgRect, currentColumn);
+          const currentExitY = currentY + currentRadius;
 
           parentIds.forEach((parentId, index) => {
             const parentNode = nodeMap.get(parentId);
@@ -666,7 +783,9 @@
               const parentColumn = Number(
                 parentNode.dataset.symbolColumn || "0",
               );
+              const parentRadius = getSymbolRadius(parentNode);
               const parentX = getLaneX(parentRect, svgRect, parentColumn);
+              const parentEntryY = parentY - parentRadius;
 
               const path = document.createElementNS(
                 "http://www.w3.org/2000/svg",
@@ -688,36 +807,63 @@
               });
 
               if (isLatestParent && currentColumn === parentColumn && isAdjacent) {
-                // Vertical line for adjacent nodes
+                // Vertical lane continuation should meet the symbol edge instead of running
+                // through the symbol center, otherwise merges read like crossings.
                 path.setAttribute(
                   "d",
                   `
-                                M ${currentX} ${currentY}
-                                L ${parentX} ${parentY}
+                                M ${currentX} ${currentExitY}
+                                L ${parentX} ${parentEntryY}
                             `,
                 );
+                edgeSpecs.push({ path, presetPath: true });
               } else {
-                // Bend close to the child node so the vertical segment at the
-                // child's column stays short and doesn't bleed through unrelated
-                // branches that share the same column.
-                const bendY = Math.min(
-                  currentY + nodeRect.height,
-                  (currentY + parentY) / 2,
-                );
-                path.setAttribute(
-                  "d",
-                  `
-                                M ${currentX} ${currentY}
-                                L ${currentX} ${bendY}
-                                L ${parentX} ${bendY}
-                                L ${parentX} ${parentY}
-                            `,
-                );
+                // For non-trunk edges, keep a single intentional diagonal
+                // between rounded exit/entry fillets.
+                edgeSpecs.push({
+                  path,
+                  currentX,
+                  currentExitY,
+                  currentColumn,
+                  parentX,
+                  parentEntryY,
+                  parentColumn,
+                  geometry: getRoundedConnectionGeometry(
+                    currentX,
+                    currentExitY,
+                    parentX,
+                    parentEntryY,
+                  ),
+                });
               }
-
-              connectionLines.appendChild(path);
             }
           });
+        });
+
+        edgeSpecs.forEach((spec) => {
+          if (spec.presetPath) {
+            // Leave pre-rendered vertical continuations untouched.
+          } else if (!spec.geometry) {
+            spec.path.setAttribute(
+              "d",
+              `
+                M ${spec.currentX} ${spec.currentExitY}
+                L ${spec.parentX} ${spec.parentEntryY}
+              `,
+            );
+          } else {
+            spec.path.setAttribute(
+              "d",
+              buildRoundedConnectionPath(
+                spec.currentX,
+                spec.currentExitY,
+                spec.parentX,
+                spec.parentEntryY,
+                spec.geometry,
+              ),
+            );
+          }
+          connectionLines.appendChild(spec.path);
         });
       }
 


### PR DESCRIPTION
## Summary

This PR refines the source control graph layout so the graph gutter reads more like `jj`'s terminal output while staying legible in a narrow sidebar.

The `mpyrkkzo` change:
- tightens lane spacing and the gap before the text column
- reshapes branch and merge connectors to use stable local fillets plus a clear diagonal run
- improves line-state contrast so default, dimmed, and highlighted paths separate more clearly

## Why

The previous graph rendering made dense areas difficult to read:
- branch and merge connectors overlapped node ownership visually
- lane spacing consumed more horizontal room than the webview could afford
- the default and highlighted line states were too similar, so hover did not do enough work

## Implementation notes

A few approaches were intentionally avoided while arriving at this version:
- tiny pixel nudges on overlapping runs made the graph look accidental rather than structured
- temporary extra tracks for conflicting runs made dense sections busier and harder to parse
- long connector curves that scaled with vertical distance looked unstable across different row gaps

The final shape keeps the connector geometry local and predictable instead of trying to solve overlap with post-hoc path distortion.

## Validation

- `npm run check-types`
- `npm run lint`
- inline webview script parse check via `node -e`

## AI attribution

This change was developed with assistance from OpenAI Codex.
