### PR TITLE
Add graph context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,48 @@
         "icon": "$(repo)"
       },
       {
+        "command": "jj.graph.new",
+        "title": "jj new",
+        "category": "Jujutsu",
+        "icon": "$(plus)"
+      },
+      {
+        "command": "jj.graph.edit",
+        "title": "jj edit",
+        "category": "Jujutsu",
+        "icon": "$(sign-in)"
+      },
+      {
+        "command": "jj.graph.duplicate",
+        "title": "jj duplicate",
+        "category": "Jujutsu",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "jj.graph.describe",
+        "title": "jj describe",
+        "category": "Jujutsu",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "jj.graph.abandon",
+        "title": "jj abandon",
+        "category": "Jujutsu",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "jj.graph.copyChangeId",
+        "title": "Copy change ID",
+        "category": "Jujutsu",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "jj.graph.copyCommitId",
+        "title": "Copy commit ID",
+        "category": "Jujutsu",
+        "icon": "$(copy)"
+      },
+      {
         "command": "jj.placeholderForFolders",
         "title": "​",
         "category": "Jujutsu",
@@ -275,6 +317,43 @@
           "command": "jj.operationRestore",
           "when": "view == jjOperationLog",
           "group": "inline"
+        }
+      ],
+      "webview/context": [
+        {
+          "command": "jj.graph.new",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphChangeIsRoot == false",
+          "group": "1_jj@1"
+        },
+        {
+          "command": "jj.graph.edit",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphChangeIsRoot == false",
+          "group": "1_jj@2"
+        },
+        {
+          "command": "jj.graph.duplicate",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphChangeIsRoot == false",
+          "group": "1_jj@3"
+        },
+        {
+          "command": "jj.graph.describe",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphChangeIsRoot == false",
+          "group": "1_jj@4"
+        },
+        {
+          "command": "jj.graph.abandon",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphChangeIsRoot == false",
+          "group": "2_danger@1"
+        },
+        {
+          "command": "jj.graph.copyChangeId",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphHasChangeId",
+          "group": "3_copy@1"
+        },
+        {
+          "command": "jj.graph.copyCommitId",
+          "when": "webviewId == 'jjGraphWebview' && webviewSection == 'changeNode' && graphHasCommitId",
+          "group": "3_copy@2"
         }
       ],
       "scm/title": [
@@ -427,6 +506,34 @@
         },
         {
           "command": "jj.selectGraphWebviewRepo",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.new",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.edit",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.duplicate",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.describe",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.abandon",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.copyChangeId",
+          "when": "false"
+        },
+        {
+          "command": "jj.graph.copyCommitId",
           "when": "false"
         },
         {

--- a/src/graphWebview.ts
+++ b/src/graphWebview.ts
@@ -6,6 +6,7 @@ import path from "path";
 type Message = {
   command: string;
   changeId?: string;
+  commitId?: string;
   selectedNodes?: string[];
 };
 
@@ -96,6 +97,12 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
   public panel?: vscode.WebviewView;
   public repository: JJRepository;
   public selectedNodes: Set<string> = new Set();
+  private contextChange:
+    | {
+        changeId: string;
+        commitId?: string;
+      }
+    | undefined;
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -164,6 +171,16 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
             );
           }
           break;
+        case "contextChange":
+          if (!message.changeId) {
+            this.contextChange = undefined;
+            break;
+          }
+          this.contextChange = {
+            changeId: message.changeId,
+            commitId: message.commitId,
+          };
+          break;
         case "selectChange":
           this.selectedNodes = new Set(message.selectedNodes ?? []);
           vscode.commands.executeCommand(
@@ -226,6 +243,7 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
     const workingCopyId = status.workingCopy.changeId;
 
     this.selectedNodes.clear();
+    this.contextChange = undefined;
     this.panel.webview.postMessage({
       command: "updateGraph",
       changes: changes,
@@ -333,6 +351,79 @@ export class JJGraphWebview implements vscode.WebviewViewProvider {
     });
 
     return res;
+  }
+
+  private getContextChangeId(): string {
+    const changeId = this.contextChange?.changeId;
+    if (!changeId) {
+      throw new Error("No graph change selected");
+    }
+    if (changeId === "zzzzzzzz") {
+      throw new Error("Cannot run this operation on root()");
+    }
+    return changeId;
+  }
+
+  public async newFromContextChange() {
+    const changeId = this.getContextChangeId();
+    await this.repository.new(undefined, [changeId]);
+  }
+
+  public async editContextChange() {
+    const changeId = this.getContextChangeId();
+    await this.repository.editRetryImmutable(changeId);
+  }
+
+  public async duplicateContextChange() {
+    const changeId = this.getContextChangeId();
+    await this.repository.duplicate(changeId);
+  }
+
+  public async describeContextChange() {
+    const changeId = this.getContextChangeId();
+    const showResult = await this.repository.show(changeId);
+    const message = await vscode.window.showInputBox({
+      prompt: "Provide a description",
+      placeHolder: "Change description here...",
+      value: showResult.change.description,
+    });
+
+    if (message === undefined) {
+      return;
+    }
+
+    await this.repository.describeRetryImmutable(changeId, message);
+  }
+
+  public async abandonContextChange() {
+    const changeId = this.getContextChangeId();
+    const abandon = "Abandon";
+    const choice = await vscode.window.showWarningMessage(
+      `Abandon change ${changeId}? Descendants will be rebased onto its parent(s). If this is the working-copy change, jj will create a new empty working-copy change.`,
+      { modal: true },
+      abandon,
+    );
+    if (choice !== abandon) {
+      return;
+    }
+
+    await this.repository.abandonRetryImmutable(changeId);
+  }
+
+  public async copyContextChangeId() {
+    const changeId = this.contextChange?.changeId;
+    if (!changeId) {
+      throw new Error("No graph change selected");
+    }
+    await vscode.env.clipboard.writeText(changeId);
+  }
+
+  public async copyContextCommitId() {
+    const commitId = this.contextChange?.commitId;
+    if (!commitId) {
+      throw new Error("No graph commit selected");
+    }
+    await vscode.env.clipboard.writeText(commitId);
   }
 
   areChangeNodesEqual(a: ChangeNode[], b: ChangeNode[]): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -992,6 +992,60 @@ export async function activate(context: vscode.ExtensionContext) {
       }),
     );
 
+    function registerGraphContextCommand(
+      command: string,
+      action: () => Promise<unknown>,
+      failureMessage: string,
+    ) {
+      context.subscriptions.push(
+        vscode.commands.registerCommand(command, async () => {
+          try {
+            await action();
+          } catch (error) {
+            vscode.window.showErrorMessage(
+              `${failureMessage}${error instanceof Error ? `: ${error.message}` : ""}`,
+            );
+          }
+        }),
+      );
+    }
+
+    registerGraphContextCommand(
+      "jj.graph.new",
+      () => graphWebview.newFromContextChange(),
+      "Failed to create change",
+    );
+    registerGraphContextCommand(
+      "jj.graph.edit",
+      () => graphWebview.editContextChange(),
+      "Failed to switch to change",
+    );
+    registerGraphContextCommand(
+      "jj.graph.duplicate",
+      () => graphWebview.duplicateContextChange(),
+      "Failed to duplicate change",
+    );
+    registerGraphContextCommand(
+      "jj.graph.describe",
+      () => graphWebview.describeContextChange(),
+      "Failed to update description",
+    );
+    registerGraphContextCommand(
+      "jj.graph.abandon",
+      () => graphWebview.abandonContextChange(),
+      "Failed to abandon change",
+    );
+    registerGraphContextCommand(
+      "jj.graph.copyChangeId",
+      () => graphWebview.copyContextChangeId(),
+      "Failed to copy change ID",
+    );
+    registerGraphContextCommand(
+      "jj.graph.copyCommitId",
+      () => graphWebview.copyContextCommitId(),
+      "Failed to copy commit ID",
+    );
+
     context.subscriptions.push(
       vscode.commands.registerCommand("jj.refreshOperationLog", async () => {
         try {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1358,6 +1358,42 @@ export class JJRepository {
     }
   }
 
+  async duplicate(rev: string) {
+    return await handleJJCommand(
+      this.spawnJJ(["duplicate", rev], {
+        defaultTimeout: 5000,
+      }),
+    );
+  }
+
+  async abandonRetryImmutable(rev: string) {
+    try {
+      return await this.abandon(rev);
+    } catch (e) {
+      if (e instanceof ImmutableError) {
+        const choice = await vscode.window.showQuickPick(["Continue"], {
+          title: `${rev} is immutable, are you sure?`,
+        });
+        if (!choice) {
+          return;
+        }
+        return await this.abandon(rev, true);
+      }
+      throw e;
+    }
+  }
+
+  async abandon(rev: string, ignoreImmutable = false) {
+    return await handleJJCommand(
+      this.spawnJJ(
+        ["abandon", rev, ...(ignoreImmutable ? ["--ignore-immutable"] : [])],
+        {
+          defaultTimeout: 5000,
+        },
+      ),
+    );
+  }
+
   async squashRetryImmutable({
     fromRev,
     toRev,

--- a/src/webview/graph.html
+++ b/src/webview/graph.html
@@ -397,6 +397,14 @@
         return rowDataByChangeId.get(changeId);
       }
 
+      function setGraphContextChange(change) {
+        vscode.postMessage({
+          command: "contextChange",
+          changeId: change.contextValue,
+          commitId: change.commitId,
+        });
+      }
+
       function getParentIds(node) {
         // Parent IDs are part of the render-scoped row state so callers can read them without
         // reparsing JSON from `dataset`.
@@ -918,6 +926,13 @@
           node.dataset.changeId = change.contextValue;
           node.dataset.branchType = change.branchType;
           node.dataset.symbolColumn = String(change.symbolColumn || 0);
+          node.dataset.vscodeContext = JSON.stringify({
+            webviewSection: "changeNode",
+            preventDefaultContextMenuItems: true,
+            graphChangeIsRoot: change.contextValue === "zzzzzzzz",
+            graphHasChangeId: Boolean(change.changeId),
+            graphHasCommitId: Boolean(change.commitId),
+          });
           // Store a shallow snapshot for hover/highlight logic; the DOM only keeps scalar lookup
           // fields that are convenient for selectors and event targeting.
           rowDataByChangeId.set(change.contextValue, { ...change });
@@ -1018,6 +1033,7 @@
 
           // Add hover handlers
           node.addEventListener("mouseenter", () => {
+            setGraphContextChange(change);
             cancelHideHoverCard();
             highlightConnectedNodes(node, true);
             scheduleShowHoverCard(change, node);
@@ -1030,6 +1046,16 @@
           node.addEventListener("mousemove", () => {
             if (!hoverCard.hidden) {
               positionHoverCard(node);
+            }
+          });
+
+          node.addEventListener("contextmenu", () => {
+            setGraphContextChange(change);
+          });
+
+          node.addEventListener("mousedown", (event) => {
+            if (event.button === 2) {
+              setGraphContextChange(change);
             }
           });
 


### PR DESCRIPTION
## Summary

- add a VS Code-native context menu to graph change rows
- expose jj-oriented actions: `jj new`, `jj edit`, `jj duplicate`, `jj describe`, and `jj abandon`
- add change/commit ID copy actions and a modal confirmation before abandoning a change

## Test Plan

- `npm run check-types`
- `npm run lint`
- `npm run compile`

`npm test` was also run before rebasing this change onto `main`; it reported 26 passing and 1 existing-looking failure in `JJFileSystemProvider diffOriginalRev reads directly from the original revision first`, where the expected file content was `before delete\n` but actual was `unexpected\n`.
