### PR TITLE
fix files showing untracked when `templates.file_list` is overridden

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -3,6 +3,9 @@ log-word-wrap = false
 paginate = "never"
 color = "never"
 
+[templates]
+file_list = 'path.display() ++ "\n"'
+
 [template-aliases]
 'commit_timestamp(commit)' = 'commit.committer().timestamp()'
 'format_short_id(id)' = 'id.shortest(8)'


### PR DESCRIPTION
If the user has overridden the `templates.file_list` or `template-aliases.format_path(path)` config values, then `jj file list` may not have the format that jjk is expecting. The result is that the file explorer shows all files as untracked (greyed out).

Setting `templates.file_list` to explicitly output plain text solves this.

Fixes #198