### PR TITLE
Add bookmark management

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,18 @@
         "category": "Jujutsu"
       },
       {
+        "command": "jj.showBookmarkMenu",
+        "title": "Show bookmarks",
+        "category": "Jujutsu",
+        "icon": "$(git-branch)"
+      },
+      {
+        "command": "jj.createBookmarkAtCurrent",
+        "title": "Create bookmark",
+        "category": "Jujutsu",
+        "icon": "$(plus)"
+      },
+      {
         "command": "jj.refreshOperationLog",
         "title": "Refresh operation log",
         "category": "Jujutsu",
@@ -285,6 +297,11 @@
         },
         {
           "command": "jj.new",
+          "when": "scmProvider == jj",
+          "group": "navigation"
+        },
+        {
+          "command": "jj.showBookmarkMenu",
           "when": "scmProvider == jj",
           "group": "navigation"
         }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
         "command": "jj.showBookmarkMenu",
         "title": "Show bookmarks",
         "category": "Jujutsu",
-        "icon": "$(git-branch)"
+        "icon": "$(bookmark)"
       },
       {
         "command": "jj.createBookmarkAtCurrent",

--- a/src/bookmarkMenu.ts
+++ b/src/bookmarkMenu.ts
@@ -1,0 +1,186 @@
+import * as vscode from "vscode";
+import type { Bookmark } from "./repository";
+
+const LOCAL_GIT_REMOTE = "git";
+
+export type BookmarkMenuItem = vscode.QuickPickItem &
+  (
+    | {
+        action: "createBookmark";
+        bookmarkName?: string;
+      }
+    | {
+        action: "editBookmark";
+        bookmark: string;
+      }
+  );
+
+export function validateBookmarkName(
+  value: string,
+  existingNames: Set<string>,
+) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "Bookmark name is required";
+  }
+  if (/\s/.test(trimmed)) {
+    return "Bookmark names cannot contain whitespace";
+  }
+  if (existingNames.has(trimmed)) {
+    return `Bookmark '${trimmed}' already exists`;
+  }
+  return undefined;
+}
+
+function bookmarkRefName(bookmark: Bookmark) {
+  return bookmark.remote
+    ? `${bookmark.name}@${bookmark.remote}`
+    : bookmark.name;
+}
+
+function compareBookmarks(a: Bookmark, b: Bookmark) {
+  const nameComparison = a.name.localeCompare(b.name);
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  return (a.remote ?? "").localeCompare(b.remote ?? "");
+}
+
+function formatBookmarkDetail(bookmark: Bookmark) {
+  if (bookmark.isConflict) {
+    return "conflicted bookmark";
+  }
+
+  const idText = [bookmark.changeId, bookmark.commitId].filter(Boolean).join(" ");
+  const description = bookmark.description || "(no description)";
+  return idText ? `${idText} ${description}` : description;
+}
+
+function createBookmarkMenuItem(name?: string): BookmarkMenuItem {
+  const bookmarkName = name?.trim() || undefined;
+  return {
+    label: bookmarkName
+      ? `$(plus) Create Bookmark '${bookmarkName}'`
+      : "$(plus) Create Bookmark...",
+    detail: "Create a new bookmark at the current change",
+    action: "createBookmark",
+    bookmarkName,
+    alwaysShow: true,
+  };
+}
+
+export function buildBookmarkMenuItems({
+  bookmarks,
+  currentBookmarks,
+  query,
+}: {
+  bookmarks: Bookmark[];
+  currentBookmarks: Set<string>;
+  query?: string;
+}) {
+  const trackedRemoteBookmarkKeys = new Set(
+    bookmarks
+      .filter(
+        (bookmark) =>
+          bookmark.isTracked &&
+          bookmark.remote &&
+          bookmark.remote !== LOCAL_GIT_REMOTE,
+      )
+      .map(bookmarkRefName),
+  );
+  const trackedRemotesByName = new Map<string, string[]>();
+  for (const bookmark of bookmarks) {
+    if (
+      !bookmark.isTracked ||
+      !bookmark.remote ||
+      bookmark.remote === LOCAL_GIT_REMOTE
+    ) {
+      continue;
+    }
+    const remotes = trackedRemotesByName.get(bookmark.name) ?? [];
+    remotes.push(bookmark.remote);
+    trackedRemotesByName.set(bookmark.name, remotes);
+  }
+
+  const localBookmarkItems: BookmarkMenuItem[] = bookmarks
+    .filter((bookmark) => !bookmark.remote && !bookmark.isConflict)
+    .sort(compareBookmarks)
+    .map((bookmark) => {
+      const trackedRemotes = [
+        ...(trackedRemotesByName.get(bookmark.name) ?? []),
+      ]
+        .sort((a, b) => a.localeCompare(b))
+        .join(", ");
+      const descriptions = [
+        ...(currentBookmarks.has(bookmark.name) ? ["current"] : []),
+        ...(trackedRemotes ? [`tracks ${trackedRemotes}`] : []),
+      ];
+
+      return {
+        label: `$(git-branch) ${bookmark.name}`,
+        description:
+          descriptions.length > 0 ? descriptions.join(" - ") : undefined,
+        detail: formatBookmarkDetail(bookmark),
+        bookmark: bookmark.name,
+        action: "editBookmark",
+      };
+    });
+
+  const remoteBookmarkItems: BookmarkMenuItem[] = bookmarks
+    .filter(
+      (bookmark) =>
+        bookmark.remote &&
+        bookmark.remote !== LOCAL_GIT_REMOTE &&
+        !bookmark.isConflict &&
+        !trackedRemoteBookmarkKeys.has(bookmarkRefName(bookmark)),
+    )
+    .sort(compareBookmarks)
+    .map((bookmark) => {
+      const name = bookmarkRefName(bookmark);
+      return {
+        label: `$(git-branch) ${name}`,
+        description: "remote",
+        detail: formatBookmarkDetail(bookmark),
+        bookmark: name,
+        action: "editBookmark",
+      };
+    });
+
+  const items: (BookmarkMenuItem | vscode.QuickPickItem)[] = [];
+  const trimmedQuery = query?.trim();
+  const existingLocalBookmarkNames = new Set(
+    bookmarks
+      .filter((bookmark) => !bookmark.remote)
+      .map((bookmark) => bookmark.name.toLocaleLowerCase()),
+  );
+
+  if (
+    !trimmedQuery ||
+    !existingLocalBookmarkNames.has(trimmedQuery.toLocaleLowerCase())
+  ) {
+    items.push(createBookmarkMenuItem(trimmedQuery));
+  }
+
+  if (localBookmarkItems.length > 0) {
+    items.push(
+      {
+        label: "Bookmarks",
+        kind: vscode.QuickPickItemKind.Separator,
+      },
+      ...localBookmarkItems,
+    );
+  }
+
+  if (remoteBookmarkItems.length > 0) {
+    items.push(
+      {
+        label: "Remote Bookmarks",
+        kind: vscode.QuickPickItemKind.Separator,
+      },
+      ...remoteBookmarkItems,
+    );
+  }
+
+  return items;
+}

--- a/src/bookmarkMenu.ts
+++ b/src/bookmarkMenu.ts
@@ -47,12 +47,20 @@ function compareBookmarks(a: Bookmark, b: Bookmark) {
   return (a.remote ?? "").localeCompare(b.remote ?? "");
 }
 
+function formatChangeId(changeId: string | undefined) {
+  if (!changeId) {
+    return undefined;
+  }
+
+  return changeId.slice(0, 8);
+}
+
 function formatBookmarkDetail(bookmark: Bookmark) {
   if (bookmark.isConflict) {
     return "conflicted bookmark";
   }
 
-  const idText = [bookmark.changeId, bookmark.commitId].filter(Boolean).join(" ");
+  const idText = formatChangeId(bookmark.changeId);
   const description = bookmark.description || "(no description)";
   return idText ? `${idText} ${description}` : description;
 }

--- a/src/bookmarkMenu.ts
+++ b/src/bookmarkMenu.ts
@@ -118,7 +118,7 @@ export function buildBookmarkMenuItems({
       ];
 
       return {
-        label: `$(git-branch) ${bookmark.name}`,
+        label: `$(bookmark) ${bookmark.name}`,
         description:
           descriptions.length > 0 ? descriptions.join(" - ") : undefined,
         detail: formatBookmarkDetail(bookmark),
@@ -139,7 +139,7 @@ export function buildBookmarkMenuItems({
     .map((bookmark) => {
       const name = bookmarkRefName(bookmark);
       return {
-        label: `$(git-branch) ${name}`,
+        label: `$(bookmark) ${name}`,
         description: "remote",
         detail: formatBookmarkDetail(bookmark),
         bookmark: name,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,12 @@ import {
   provideOriginalResource,
   WorkspaceSourceControlManager,
 } from "./repository";
-import type { JJRepository, ChangeWithDetails, FileStatus } from "./repository";
+import type {
+  JJRepository,
+  ChangeWithDetails,
+  FileStatus,
+  RepositorySourceControlManager,
+} from "./repository";
 import { JJDecorationProvider } from "./decorationProvider";
 import {
   OperationLogManager,
@@ -25,6 +30,11 @@ import {
 } from "./vendor/vscode/editor/common/diff/linesDiffComputer";
 import { match } from "arktype";
 import { getActiveTextEditorDiff, pathEquals } from "./utils";
+import {
+  type BookmarkMenuItem,
+  buildBookmarkMenuItems,
+  validateBookmarkName,
+} from "./bookmarkMenu";
 
 export async function activate(context: vscode.ExtensionContext) {
   const outputChannel = vscode.window.createOutputChannel("Jujutsu Kaizen", {
@@ -160,29 +170,187 @@ export async function activate(context: vscode.ExtensionContext) {
         if (graphWebview.repository.repositoryRoot === repoSCM.repositoryRoot) {
           void graphWebview.refresh();
         }
+        updateBookmarkStatusBarItem();
+        updateFetchStatusBarItem();
       }),
     );
 
-    const statusBarItem = vscode.window.createStatusBarItem(
+    const bookmarkStatusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
+      101,
+    );
+    const fetchStatusBarItem = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Left,
       100,
     );
-    context.subscriptions.push(statusBarItem);
-    statusBarItem.command = "jj.gitFetch";
+    context.subscriptions.push(bookmarkStatusBarItem, fetchStatusBarItem);
+    bookmarkStatusBarItem.name = "Jujutsu Bookmark";
+    bookmarkStatusBarItem.command = "jj.showBookmarkMenu";
+    fetchStatusBarItem.name = "Jujutsu Fetch";
+    fetchStatusBarItem.command = "jj.gitFetch";
     let lastOpenedFileUri: vscode.Uri | undefined;
+    const getStatusBarRepoSCM = () => {
+      if (lastOpenedFileUri) {
+        const repoSCM =
+          workspaceSCM.getRepositorySourceControlManagerFromUri(
+            lastOpenedFileUri,
+          );
+        if (repoSCM) {
+          return repoSCM;
+        }
+      }
+
+      const selectedRepo =
+        context.workspaceState.get<string>("selectedRepository");
+      if (selectedRepo) {
+        return workspaceSCM.repoSCMs.find(
+          (repoSCM) => repoSCM.repositoryRoot === selectedRepo,
+        );
+      }
+
+      return workspaceSCM.repoSCMs[0];
+    };
+
+    function isBookmarkMenuItem(
+      item: BookmarkMenuItem | vscode.QuickPickItem | undefined,
+    ): item is BookmarkMenuItem {
+      return Boolean(item && "action" in item);
+    }
+
+    async function showBookmarkMenu({
+      bookmarks,
+      currentBookmarks,
+    }: Parameters<typeof buildBookmarkMenuItems>[0]) {
+      return await new Promise<BookmarkMenuItem | undefined>((resolve) => {
+        const quickPick = vscode.window.createQuickPick<
+          BookmarkMenuItem | vscode.QuickPickItem
+        >();
+        let resolved = false;
+
+        const finish = (selection: BookmarkMenuItem | undefined) => {
+          if (resolved) {
+            return;
+          }
+          resolved = true;
+          resolve(selection);
+          quickPick.hide();
+        };
+
+        const updateItems = () => {
+          const items = buildBookmarkMenuItems({
+            bookmarks,
+            currentBookmarks,
+            query: quickPick.value,
+          });
+          quickPick.items = items;
+        };
+
+        quickPick.title = "Jujutsu Bookmarks";
+        quickPick.placeholder = "Create a bookmark or select a bookmark to edit";
+        quickPick.matchOnDescription = true;
+        quickPick.matchOnDetail = true;
+        updateItems();
+
+        quickPick.onDidChangeValue(updateItems);
+        quickPick.onDidAccept(() => {
+          finish(
+            quickPick.selectedItems.find(isBookmarkMenuItem) ??
+              quickPick.activeItems.find(isBookmarkMenuItem),
+          );
+        });
+        quickPick.onDidHide(() => {
+          finish(undefined);
+          quickPick.dispose();
+        });
+        quickPick.show();
+      });
+    }
+
+    async function createBookmarkAtCurrent(
+      repoSCM: RepositorySourceControlManager,
+      bookmarkName?: string,
+      existingNames?: Set<string>,
+    ) {
+      const knownNames =
+        existingNames ??
+        new Set(
+          (await repoSCM.repository.listBookmarks()).map(
+            (bookmark) => bookmark.name,
+          ),
+        );
+
+      const validateInput = (value: string) =>
+        validateBookmarkName(value, knownNames);
+
+      const name =
+        bookmarkName ??
+        (await vscode.window.showInputBox({
+          title: "Create Bookmark",
+          prompt: "Create a new bookmark at the current change",
+          placeHolder: "bookmark-name",
+          validateInput,
+        }));
+
+      if (!name) {
+        return;
+      }
+
+      const validationMessage = validateInput(name);
+      if (validationMessage) {
+        vscode.window.showErrorMessage(validationMessage);
+        return;
+      }
+
+      await repoSCM.repository.createBookmark(name.trim());
+      await poll();
+    }
+
+    function updateBookmarkStatusBarItem() {
+      const repoSCM = getStatusBarRepoSCM();
+      if (!repoSCM?.status) {
+        bookmarkStatusBarItem.hide();
+        return;
+      }
+
+      const folderName = path.basename(repoSCM.repositoryRoot);
+      const workingCopy = repoSCM.status.workingCopy;
+      const currentBookmarks = workingCopy.bookmarks ?? [];
+
+      if (currentBookmarks.length > 0) {
+        const bookmarkLabel =
+          currentBookmarks.length === 1
+            ? currentBookmarks[0]
+            : `${currentBookmarks[0]} +${currentBookmarks.length - 1}`;
+        bookmarkStatusBarItem.text = `$(git-branch) ${bookmarkLabel}`;
+        bookmarkStatusBarItem.tooltip = `${folderName} - Current bookmark: ${currentBookmarks.join(", ")}\nChange: ${workingCopy.changeId}\nCommit: ${workingCopy.commitId}\nClick for bookmark actions`;
+      } else {
+        bookmarkStatusBarItem.text = `$(git-commit) ${workingCopy.changeId}`;
+        bookmarkStatusBarItem.tooltip = `${folderName} - Current change: ${workingCopy.changeId}\nCommit: ${workingCopy.commitId}\nClick for bookmark actions`;
+      }
+
+      bookmarkStatusBarItem.show();
+    }
+
+    function updateFetchStatusBarItem() {
+      const repoSCM = getStatusBarRepoSCM();
+      if (!repoSCM) {
+        fetchStatusBarItem.hide();
+        return;
+      }
+
+      const folderName = path.basename(repoSCM.repositoryRoot);
+      fetchStatusBarItem.text = "$(cloud-download)";
+      fetchStatusBarItem.tooltip = `${folderName} - Run \`jj git fetch\``;
+      fetchStatusBarItem.show();
+    }
     const statusBarHandleDidChangeActiveTextEditor = (
       editor: vscode.TextEditor | undefined,
     ) => {
       if (editor && editor.document.uri.scheme === "file") {
         lastOpenedFileUri = editor.document.uri;
-        const repository = workspaceSCM.getRepositoryFromUri(lastOpenedFileUri);
-        if (repository) {
-          const folderName = repository.repositoryRoot.split("/").at(-1)!;
-          statusBarItem.text = "$(cloud-download)";
-          statusBarItem.tooltip = `${folderName} – Run \`jj git fetch\``;
-          statusBarItem.show();
-        }
       }
+      updateBookmarkStatusBarItem();
+      updateFetchStatusBarItem();
     };
     context.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(
@@ -1081,22 +1249,87 @@ export async function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(
-      vscode.commands.registerCommand("jj.gitFetch", async () => {
-        if (lastOpenedFileUri) {
-          statusBarItem.text = "$(sync~spin)";
-          statusBarItem.tooltip = "Fetching...";
+      vscode.commands.registerCommand("jj.showBookmarkMenu", async () => {
+        try {
+          const repoSCM = getStatusBarRepoSCM();
+          if (!repoSCM) {
+            throw new Error("Repository not found");
+          }
+
+          const bookmarks = await repoSCM.repository.listBookmarks({
+            allRemotes: true,
+          });
+          const currentBookmarks = new Set(
+            repoSCM.status?.workingCopy.bookmarks ?? [],
+          );
+
+          const selection = await showBookmarkMenu({
+            bookmarks,
+            currentBookmarks,
+          });
+
+          if (!selection || !("action" in selection)) {
+            return;
+          }
+
+          if (selection.action === "createBookmark") {
+            await createBookmarkAtCurrent(
+              repoSCM,
+              selection.bookmarkName,
+              new Set(bookmarks.map((bookmark) => bookmark.name)),
+            );
+          } else if (selection.action === "editBookmark") {
+            await repoSCM.repository.editRetryImmutable(selection.bookmark);
+            await poll();
+          }
+        } catch (error) {
+          vscode.window.showErrorMessage(
+            `Failed to show bookmarks${error instanceof Error ? `: ${error.message}` : ""}`,
+          );
+        }
+      }),
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "jj.createBookmarkAtCurrent",
+        async (repositoryRoot?: string, bookmarkName?: string) => {
           try {
-            await workspaceSCM
-              .getRepositoryFromUri(lastOpenedFileUri)
-              ?.gitFetch();
+            const repoSCM = repositoryRoot
+              ? workspaceSCM.repoSCMs.find(
+                  (repoSCM) => repoSCM.repositoryRoot === repositoryRoot,
+                )
+              : getStatusBarRepoSCM();
+            if (!repoSCM) {
+              throw new Error("Repository not found");
+            }
+
+            await createBookmarkAtCurrent(repoSCM, bookmarkName);
+          } catch (error) {
+            vscode.window.showErrorMessage(
+              `Failed to create bookmark${error instanceof Error ? `: ${error.message}` : ""}`,
+            );
+          }
+        },
+      ),
+    );
+
+    context.subscriptions.push(
+      vscode.commands.registerCommand("jj.gitFetch", async () => {
+        const repoSCM = getStatusBarRepoSCM();
+        if (repoSCM) {
+          fetchStatusBarItem.text = "$(sync~spin)";
+          fetchStatusBarItem.tooltip = "Fetching...";
+          try {
+            await repoSCM.repository.gitFetch();
+            await poll();
           } catch (error) {
             vscode.window.showErrorMessage(
               `Failed to fetch from remote${error instanceof Error ? `: ${error.message}` : ""}`,
             );
           } finally {
-            statusBarHandleDidChangeActiveTextEditor(
-              vscode.window.activeTextEditor,
-            );
+            updateBookmarkStatusBarItem();
+            updateFetchStatusBarItem();
           }
         }
       }),
@@ -1690,6 +1923,7 @@ export async function activate(context: vscode.ExtensionContext) {
     workspaceSCM,
     uri: await import("./uri"),
     repository: await import("./repository"),
+    bookmarkMenu: await import("./bookmarkMenu"),
     graphWebview: await import("./graphWebview"),
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -321,7 +321,7 @@ export async function activate(context: vscode.ExtensionContext) {
           currentBookmarks.length === 1
             ? currentBookmarks[0]
             : `${currentBookmarks[0]} +${currentBookmarks.length - 1}`;
-        bookmarkStatusBarItem.text = `$(git-branch) ${bookmarkLabel}`;
+        bookmarkStatusBarItem.text = `$(bookmark) ${bookmarkLabel}`;
         bookmarkStatusBarItem.tooltip = `${folderName} - Current bookmark: ${currentBookmarks.join(", ")}\nChange: ${workingCopy.changeId}\nCommit: ${workingCopy.commitId}\nClick for bookmark actions`;
       } else {
         bookmarkStatusBarItem.text = `$(git-commit) ${workingCopy.changeId}`;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -6,6 +6,7 @@ import * as fsSync from "fs";
 import { getParams, toJJUri } from "./uri";
 import {
   CommitT,
+  CommitRefExpr,
   OperationT,
   Expr,
   str,
@@ -967,6 +968,45 @@ const operationRecordTemplate = template({
   .field("snapshot", operation.snapshot())
   .build();
 
+const BOOKMARK_FIELD_SEPARATOR = "\x1f";
+const bookmark = new CommitRefExpr({ kind: "keyword", name: "self" });
+const bookmarkTarget = bookmark.normal_target();
+const bookmarkRecordTemplate = template({
+  fieldSeparator: BOOKMARK_FIELD_SEPARATOR,
+  recordSeparator: "\n",
+})
+  .field("name", bookmark.name())
+  .field("remote", jjIf(bookmark.remote(), bookmark.remote(), str("")))
+  .field(
+    "changeId",
+    jjIf(bookmarkTarget, bookmarkTarget.change_id().shortest(), str("")),
+  )
+  .field(
+    "commitId",
+    jjIf(bookmarkTarget, bookmarkTarget.commit_id().short(), str("")),
+  )
+  .field(
+    "description",
+    jjIf(
+      bookmarkTarget,
+      bookmarkTarget.description().first_line().escape_json(),
+      str('""'),
+    ),
+  )
+  .field("conflict", jjIf(bookmark.conflict(), str("conflict"), str("")))
+  .field("tracked", jjIf(bookmark.tracked(), str("tracked"), str("")))
+  .build();
+
+export type Bookmark = {
+  name: string;
+  remote?: string;
+  changeId?: string;
+  commitId?: string;
+  description?: string;
+  isConflict: boolean;
+  isTracked: boolean;
+};
+
 export class JJRepository {
   statusCache: RepositoryStatus | undefined;
   gitFetchPromise: Promise<void> | undefined;
@@ -1786,6 +1826,67 @@ export class JJRepository {
           defaultTimeout: 5000,
         },
       ),
+    );
+  }
+
+  async listBookmarks({
+    allRemotes = false,
+  }: { allRemotes?: boolean } = {}) {
+    const output = (
+      await handleJJCommand(
+        this.spawnJJRead(
+          [
+            "bookmark",
+            "list",
+            ...(allRemotes ? ["--all-remotes"] : []),
+            "-T",
+            bookmarkRecordTemplate.template,
+          ],
+          {
+            defaultTimeout: 5000,
+          },
+        ),
+      )
+    ).toString();
+
+    return output
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [
+          name,
+          remote,
+          changeId,
+          commitId,
+          description,
+          conflict,
+          tracked,
+        ] = line.split(BOOKMARK_FIELD_SEPARATOR);
+        if (!name) {
+          throw new Error("Missing bookmark name in jj bookmark list output.");
+        }
+        const parsedDescription: unknown = JSON.parse(description || '""');
+        if (typeof parsedDescription !== "string") {
+          throw new Error("Unexpected bookmark description JSON payload.");
+        }
+        return {
+          name,
+          remote: remote || undefined,
+          changeId: changeId || undefined,
+          commitId: commitId || undefined,
+          description: parsedDescription || undefined,
+          isConflict: conflict === "conflict",
+          isTracked: tracked === "tracked",
+        } satisfies Bookmark;
+      });
+  }
+
+  async createBookmark(name: string) {
+    return await handleJJCommand(
+      this.spawnJJ(["bookmark", "create", name, "--revision", "@"], {
+        defaultTimeout: 5000,
+      }),
     );
   }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -979,7 +979,7 @@ const bookmarkRecordTemplate = template({
   .field("remote", jjIf(bookmark.remote(), bookmark.remote(), str("")))
   .field(
     "changeId",
-    jjIf(bookmarkTarget, bookmarkTarget.change_id().shortest(), str("")),
+    jjIf(bookmarkTarget, bookmarkTarget.change_id(), str("")),
   )
   .field(
     "commitId",

--- a/src/test/extensionApi.ts
+++ b/src/test/extensionApi.ts
@@ -4,11 +4,13 @@ import type * as RepositoryModule from "../repository";
 import type { WorkspaceSourceControlManager } from "../repository";
 import type * as UriModule from "../uri";
 import type * as GraphWebviewModule from "../graphWebview";
+import type * as BookmarkMenuModule from "../bookmarkMenu";
 
 type ExtensionAPI = {
   workspaceSCM: WorkspaceSourceControlManager;
   uri: typeof UriModule;
   repository: typeof RepositoryModule;
+  bookmarkMenu: typeof BookmarkMenuModule;
   graphWebview: typeof GraphWebviewModule;
 };
 


### PR DESCRIPTION
## Summary
Adds bookmark management so users can view, create, and jump to bookmarks from the UI.
- Adds a bookmark status bar item that shows the current bookmark or change and opens bookmark actions.
- Adds commands for showing bookmarks and creating a bookmark at the current change.
- Adds repository support for `jj bookmark list` and `jj bookmark create`, including local, remote, tracked, and conflicted bookmark metadata.
- Updates fetch/status bar handling to work from the selected or active repository context.

<img width="625" height="352" alt="image" src="https://github.com/user-attachments/assets/fc462a66-9bed-44f0-b480-713a88b4906a" />

Related issue #248 