### PR TITLE
Detect nested jj repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -481,6 +481,51 @@
           "default": true,
           "description": "Whether the periodic poll command (jj operation log) should snapshot the working copy. When enabled, file changes are automatically detected; when disabled, modified files may not auto-update until the next manual jj command.",
           "scope": "resource"
+        },
+        "jjk.autoRepositoryDetection": {
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            true,
+            false,
+            "subFolders"
+          ],
+          "enumDescriptions": [
+            "Scan for subfolders of the current opened folder.",
+            "Disable automatic repository scanning.",
+            "Scan for subfolders of the current opened folder."
+          ],
+          "default": true,
+          "description": "Configures when nested repositories should be automatically detected.",
+          "scope": "resource"
+        },
+        "jjk.repositoryScanMaxDepth": {
+          "type": "number",
+          "default": 1,
+          "description": "Controls the depth used when scanning workspace folders for jj repositories. Can be set to -1 for no limit.",
+          "scope": "resource"
+        },
+        "jjk.repositoryScanIgnoredFolders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "node_modules"
+          ],
+          "description": "List of folders that are ignored while scanning for jj repositories.",
+          "scope": "resource"
+        },
+        "jjk.scanRepositories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "List of additional workspace-relative paths to search for jj repositories in. Absolute paths and paths outside the workspace are ignored.",
+          "scope": "resource"
         }
       }
     },

--- a/src/effectRunners.ts
+++ b/src/effectRunners.ts
@@ -55,7 +55,7 @@ export const retryImmutable = <A>(
           if (!choice) {
             return undefined as A | undefined;
           }
-          return (yield* retryEffect) as A | undefined;
+          return yield* retryEffect;
         }),
     ),
   );

--- a/src/jjUtils.ts
+++ b/src/jjUtils.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import * as fsSync from "fs";
+import fs from "fs/promises";
 import * as os from "os";
 import * as vscode from "vscode";
 import spawn from "cross-spawn";
@@ -13,6 +14,7 @@ import {
   getWorkspaceFolders,
   Vscode,
 } from "./services/Vscode";
+import { isDescendant, pathEquals } from "./utils";
 
 export interface DiscoveredRepoInfo {
   jjPath: { filepath: string; source: "configured" | "path" | "common" };
@@ -160,6 +162,323 @@ export function getJJPathEffect(
   });
 }
 
+/**
+ * Builds the list of directories that should be probed with `jj root`.
+ *
+ * A VS Code workspace folder is always a candidate because opening a repo root
+ * must continue to work even when automatic nested detection is disabled. When
+ * nested detection is enabled, immediate children are considered by default,
+ * matching VS Code Git's guarded scan shape without requiring users to create
+ * a multi-root workspace for sibling repos under a container directory. For
+ * example, opening `~/code` can discover `~/code/foo` and `~/code/bar` without
+ * also walking every descendant under those repos.
+ *
+ * `jjk.scanRepositories` is a narrow escape hatch for known relative paths. It
+ * is intentionally relative to the workspace folder so a shared setting cannot
+ * make this extension crawl arbitrary absolute paths on another machine.
+ */
+function getRepositoryScanFolders(
+  workspaceFolder: vscode.WorkspaceFolder,
+): Effect.Effect<Set<string>, never, Vscode> {
+  return Effect.gen(function* () {
+    const root = workspaceFolder.uri.fsPath;
+    const result = new Set<string>([root]);
+    const configScope = workspaceFolder.uri;
+
+    if (yield* shouldScanWorkspaceSubfolders(configScope)) {
+      const repositoryScanMaxDepth =
+        (yield* getConfigurationValue<number>(
+          "jjk",
+          "repositoryScanMaxDepth",
+          configScope,
+        )) ?? 1;
+      const repositoryScanIgnoredFolders = (yield* getConfigurationValue<
+        string[]
+      >("jjk", "repositoryScanIgnoredFolders", configScope)) ?? [
+        "node_modules",
+      ];
+
+      for (const folder of yield* traverseWorkspaceFolder(
+        root,
+        repositoryScanMaxDepth,
+        repositoryScanIgnoredFolders,
+      )) {
+        result.add(folder);
+      }
+    }
+
+    const scanRepositories =
+      (yield* getConfigurationValue<string[]>(
+        "jjk",
+        "scanRepositories",
+        configScope,
+      )) ?? [];
+    for (const folder of getConfiguredScanFolders(root, scanRepositories)) {
+      result.add(folder);
+    }
+
+    return result;
+  });
+}
+
+/**
+ * Decides whether workspace children should be scanned automatically.
+ *
+ * The setting mirrors VS Code Git's public shape so users can transfer the same
+ * mental model to jjk. Both `true` and `"subFolders"` mean "probe workspace
+ * children"; `false` still leaves the opened workspace folder and explicit
+ * `jjk.scanRepositories` entries in place.
+ */
+function shouldScanWorkspaceSubfolders(
+  configScope: vscode.ConfigurationScope,
+): Effect.Effect<boolean, never, Vscode> {
+  return Effect.map(
+    getConfigurationValue<boolean | "subFolders">(
+      "jjk",
+      "autoRepositoryDetection",
+      configScope,
+    ),
+    (autoRepositoryDetection) =>
+      autoRepositoryDetection === undefined ||
+      autoRepositoryDetection === true ||
+      autoRepositoryDetection === "subFolders",
+  );
+}
+
+/**
+ * Expands explicit scan paths from settings into workspace-local candidates.
+ *
+ * These entries are for repos that live outside the bounded automatic scan, for
+ * example a known grandchild repo when `jjk.repositoryScanMaxDepth` is left at
+ * the default. If the workspace is `~/code`, an entry like `tools/jjk` probes
+ * `~/code/tools/jjk` even though only direct children are scanned
+ * automatically. Keeping entries relative to the workspace prevents a shared
+ * setting from causing this extension to probe unrelated absolute paths on
+ * another machine.
+ */
+function getConfiguredScanFolders(
+  root: string,
+  scanRepositories: string[],
+): string[] {
+  const result: string[] = [];
+
+  for (const scanPath of scanRepositories) {
+    const scanFolder = resolveConfiguredScanFolder(root, scanPath);
+    if (scanFolder === undefined) {
+      continue;
+    }
+
+    result.push(scanFolder);
+  }
+
+  return result;
+}
+
+/**
+ * Resolves one `jjk.scanRepositories` entry into a workspace-local probe.
+ *
+ * `scanRepositories` names candidate workspaces, not repository metadata
+ * directories. Accepting `.jj` or `.git` would just make `jj root` walk back to
+ * the same checkout while making the configured path harder to reason about.
+ *
+ * The returned path must stay inside the opened workspace after normalization.
+ * For example, `tools/jjk` under `~/code` is accepted as `~/code/tools/jjk`,
+ * but `../other` and `tools/../../other` are rejected because they escape the
+ * workspace root.
+ */
+export function resolveConfiguredScanFolder(
+  root: string,
+  scanPath: string,
+): string | undefined {
+  const normalizedScanPath = path.normalize(scanPath);
+
+  if (normalizedScanPath === ".jj" || normalizedScanPath === ".git") {
+    logger.debug(
+      `Skipping unsupported '${scanPath}' entry in jjk.scanRepositories setting.`,
+    );
+    return undefined;
+  }
+
+  if (path.isAbsolute(scanPath)) {
+    logger.warn(
+      "Skipping absolute path in jjk.scanRepositories setting: " + scanPath,
+    );
+    return undefined;
+  }
+
+  const scanFolder = path.resolve(root, scanPath);
+  if (!isDescendant(root, scanFolder)) {
+    logger.warn(
+      "Skipping path outside workspace in jjk.scanRepositories setting: " +
+        scanPath,
+    );
+    return undefined;
+  }
+
+  return scanFolder;
+}
+
+/**
+ * Returns subfolders that are worth probing as possible repository roots.
+ *
+ * The workspace folder itself is not returned here; `getRepositoryScanFolders`
+ * owns that invariant so callers can combine the root, automatic discovery, and
+ * explicit scan paths in one deduplicated set. `maxDepth` follows the Git
+ * extension setting shape: `1` means direct children, so `~/code/foo` is
+ * returned but `~/code/foo/crate` is not; `-1` means unlimited. A folder is a
+ * candidate as soon as traversal reaches it, even if its children cannot be
+ * read. For example, an unreadable `~/code/foo` at depth 1 is still worth a
+ * `jj root` probe because the probe does not require listing `foo` first.
+ *
+ * `.jj` and `.git` are repository metadata, not useful candidate workspaces.
+ * Skipping them avoids an extra `jj root` per colocated repo and prevents
+ * deeper metadata internals from becoming scan roots when depth is unlimited.
+ */
+export function traverseWorkspaceFolder(
+  workspaceFolder: string,
+  maxDepth: number,
+  repositoryScanIgnoredFolders: string[],
+): Effect.Effect<string[]> {
+  return Effect.gen(function* () {
+    const result: string[] = [];
+    const foldersToTraverse = [{ path: workspaceFolder, depth: 0 }];
+
+    while (foldersToTraverse.length > 0) {
+      const currentFolder = foldersToTraverse.shift()!;
+
+      if (currentFolder.depth !== 0) {
+        result.push(currentFolder.path);
+      }
+
+      if (currentFolder.depth >= maxDepth && maxDepth !== -1) {
+        continue;
+      }
+
+      const children = yield* readWorkspaceChildren(currentFolder.path);
+
+      if (children === undefined) {
+        continue;
+      }
+
+      foldersToTraverse.push(
+        ...children
+          .filter((dirent) =>
+            isWorkspaceScanFolder(dirent, repositoryScanIgnoredFolders),
+          )
+          .map((dirent) => ({
+            path: path.join(currentFolder.path, dirent.name),
+            depth: currentFolder.depth + 1,
+          })),
+      );
+    }
+
+    return result;
+  });
+}
+
+/**
+ * Reads one directory during repository discovery without aborting the scan.
+ *
+ * Workspace scans should be best-effort: unreadable generated folders,
+ * permission-limited directories, or deleted paths should not prevent other
+ * sibling repositories from being discovered.
+ */
+function readWorkspaceChildren(
+  folder: string,
+): Effect.Effect<fsSync.Dirent[] | undefined> {
+  return Effect.tryPromise({
+    try: () => fs.readdir(folder, { withFileTypes: true }),
+    catch: (err) => (err instanceof Error ? err : new Error(String(err))),
+  }).pipe(
+    Effect.catchAll((err) => {
+      logger.warn(
+        `Unable to read workspace folder '${folder}': ${String(err)}`,
+      );
+      return Effect.succeed(undefined);
+    }),
+  );
+}
+
+/**
+ * Applies the traversal policy for automatic workspace scans.
+ *
+ * The scan only descends into directories that could be useful workspace roots.
+ * Repository metadata directories are skipped because they cannot be opened as
+ * jj workspaces, and user-configured ignored folders let large dependency trees
+ * stay out of the probe set.
+ */
+function isWorkspaceScanFolder(
+  dirent: fsSync.Dirent,
+  repositoryScanIgnoredFolders: string[],
+): boolean {
+  return (
+    dirent.isDirectory() &&
+    dirent.name !== ".jj" &&
+    dirent.name !== ".git" &&
+    !repositoryScanIgnoredFolders.some((folder) =>
+      pathEquals(dirent.name, folder),
+    )
+  );
+}
+
+/**
+ * Converts a candidate folder into canonical repository information.
+ *
+ * Most candidate folders are just probes. The important output is not the
+ * candidate path, but the root reported by `jj root`, because several
+ * candidates can resolve to the same repository through parent lookup,
+ * symlinks, or explicit scan paths. For example, probing both `~/code/foo` and
+ * `~/code/foo/src` should open one repo keyed by `~/code/foo`, not two source
+ * control managers.
+ *
+ * `jj root` is the first jj command on purpose. During a workspace scan, most
+ * candidates may be ordinary folders. Waiting to call `jj version` until after
+ * a root is found avoids one extra process spawn for every non-repo child.
+ */
+function discoverRepository(
+  candidateFolder: string,
+): Effect.Effect<[string, DiscoveredRepoInfo], Error, Vscode> {
+  return Effect.gen(function* () {
+    const jjPath = yield* getJJPathEffect(candidateFolder);
+    const repoRoot = (yield* handleCommand(
+      spawn(jjPath.filepath, ["--ignore-working-copy", "root"], {
+        cwd: candidateFolder,
+        timeout: 5000,
+      }),
+    ))
+      .toString()
+      .trim();
+
+    const jjVersion = yield* getJJVersion(jjPath.filepath);
+    if (semver.lt(jjVersion, "0.27.0")) {
+      return yield* Effect.fail(
+        new Error(
+          `jj version ${jjVersion} is not supported. Please upgrade to at least jj 0.27.0.`,
+        ),
+      );
+    }
+
+    return [
+      repositoryUriFromRoot(repoRoot),
+      {
+        jjPath,
+        jjVersion,
+        repoRoot,
+      },
+    ];
+  });
+}
+
+/**
+ * Converts a canonical jj root into the URI key used to track open repos.
+ *
+ * Repository identity is keyed by VS Code's URI string form, so UNC roots need
+ * normalization before the key is compared against existing repo handles.
+ */
+function repositoryUriFromRoot(repoRoot: string): string {
+  return vscode.Uri.file(repoRoot.replace(/^\\\\\?\\UNC\\/, "\\\\")).toString();
+}
+
 export function discoverRepositoriesEffect(): Effect.Effect<
   Map<string, DiscoveredRepoInfo>,
   never,
@@ -170,49 +489,24 @@ export function discoverRepositoriesEffect(): Effect.Effect<
 
     const workspaceFolders = yield* getWorkspaceFolders();
     for (const workspaceFolder of workspaceFolders) {
-      const result = yield* Effect.either(
-        Effect.gen(function* () {
-          const jjPath = yield* getJJPathEffect(workspaceFolder.uri.fsPath);
-          const jjVersion = yield* getJJVersion(jjPath.filepath);
+      const candidateFolders = yield* getRepositoryScanFolders(workspaceFolder);
 
-          if (semver.lt(jjVersion, "0.27.0")) {
-            return yield* Effect.fail(
-              new Error(
-                `jj version ${jjVersion} is not supported. Please upgrade to at least jj 0.27.0.`,
-              ),
-            );
-          }
+      for (const candidateFolder of candidateFolders) {
+        const result = yield* Effect.either(
+          discoverRepository(candidateFolder),
+        );
+        if (result._tag === "Right") {
+          const [repoUri, repoInfo] = result.right;
+          repoInfos.set(repoUri, repoInfos.get(repoUri) ?? repoInfo);
+          continue;
+        }
 
-          const repoRoot = (yield* handleCommand(
-            spawn(jjPath.filepath, ["--ignore-working-copy", "root"], {
-              cwd: workspaceFolder.uri.fsPath,
-              timeout: 5000,
-            }),
-          ))
-            .toString()
-            .trim();
-
-          const repoUri = vscode.Uri.file(
-            repoRoot.replace(/^\\\\\?\\UNC\\/, "\\\\"),
-          ).toString();
-
-          if (!repoInfos.has(repoUri)) {
-            repoInfos.set(repoUri, {
-              jjPath,
-              jjVersion,
-              repoRoot,
-            });
-          }
-        }),
-      );
-
-      if (result._tag === "Left") {
         const e = result.left;
-        if (e instanceof Error && e.message.includes("no jj repo in")) {
-          logger.debug(`No jj repo in ${workspaceFolder.uri.fsPath}`);
+        if (e.message.includes("no jj repo in")) {
+          logger.debug(`No jj repo in ${candidateFolder}`);
         } else {
           logger.error(
-            `Error while initializing jjk in workspace ${workspaceFolder.uri.fsPath}: ${String(e)}`,
+            `Error while initializing jjk in workspace ${candidateFolder}: ${String(e)}`,
           );
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import * as vscode from "vscode";
 import { Effect, ManagedRuntime, Scope } from "effect";
-import { resolveRepoPath } from "./jjUtils";
+import {
+  resolveConfiguredScanFolder,
+  resolveRepoPath,
+  traverseWorkspaceFolder,
+} from "./jjUtils";
 import { parseRenamePaths } from "./parsers";
 import { JJDecorationProvider } from "./decorationProvider";
 import {
@@ -142,9 +146,6 @@ export async function activate(context: vscode.ExtensionContext) {
   await repoLifecycle.initializeDiscoveredRepos();
   const { syncReposWithWorkspaceFolders, poll } = repoLifecycle;
 
-  // --- Lazy init flag ---
-  let isInitialized = false;
-
   // --- Check for colocated repos ---
   const colocatedWarnings = await setupColocatedWarnings({
     repos: () => repos,
@@ -200,6 +201,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
   await registerScoped(() =>
     vscode.workspace.onDidChangeConfiguration((e) => {
+      if (
+        e.affectsConfiguration("jjk.autoRepositoryDetection") ||
+        e.affectsConfiguration("jjk.repositoryScanMaxDepth") ||
+        e.affectsConfiguration("jjk.repositoryScanIgnoredFolders") ||
+        e.affectsConfiguration("jjk.scanRepositories")
+      ) {
+        logger.info("jjk repository discovery configuration changed");
+        dispatchExtensionEffect(
+          syncReposWithWorkspaceFolders().pipe(Effect.zipRight(poll())),
+          "Failed to sync repository discovery settings",
+        );
+      }
+
       if (e.affectsConfiguration("git")) {
         logger.info("Git configuration changed");
         const workspaceFolders = vscode.workspace.workspaceFolders || [];
@@ -216,7 +230,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
   );
 
-  if (repos.length > 0 && !isInitialized) {
+  if (repos.length > 0) {
     extensionViews = await initializeExtensionViews({
       extensionUri: context.extensionUri,
       repos: () => repos,
@@ -233,7 +247,6 @@ export async function activate(context: vscode.ExtensionContext) {
           setContext("jjGraphView.nodesSelected", count).pipe(Effect.asVoid),
         ),
     });
-    isInitialized = extensionViews !== undefined;
   }
 
   await registerGlobalCommands(
@@ -299,6 +312,11 @@ export async function activate(context: vscode.ExtensionContext) {
     () => repos,
     fileSystemProvider,
     repoLocator,
+    () =>
+      runExtensionEffect(
+        syncReposWithWorkspaceFolders().pipe(Effect.zipRight(poll())),
+        "Failed to refresh repositories",
+      ).then(() => true),
   );
 
   return {
@@ -308,6 +326,19 @@ export async function activate(context: vscode.ExtensionContext) {
     repository: {
       parseRenamePaths,
       resolveRepoPath,
+      traverseWorkspaceFolder: (
+        workspaceFolder: string,
+        maxDepth: number,
+        repositoryScanIgnoredFolders: string[],
+      ) =>
+        extensionRuntime.runPromise(
+          traverseWorkspaceFolder(
+            workspaceFolder,
+            maxDepth,
+            repositoryScanIgnoredFolders,
+          ),
+        ),
+      resolveConfiguredScanFolder,
       fakeEditorPath: extensionResourcesConfig.fakeEditorPath,
       ImmutableError: class ImmutableError extends Error {
         constructor(message: string) {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -530,7 +530,9 @@ export function parseOperationLog(
           op.snapshot = value === "true";
           break;
         default:
-          throw new Error(`Unexpected operation log field: ${rt.fields[i].name}`);
+          throw new Error(
+            `Unexpected operation log field: ${rt.fields[i].name}`,
+          );
       }
     }
     ret.push(op);
@@ -571,7 +573,7 @@ export function parseLog(output: string): ChangeNode[] {
 
   for (let i = 0; i < lines.length; i += 2) {
     const oddLine = lines[i];
-    let evenLine = lines[i + 1] || "";
+    const evenLine = lines[i + 1] || "";
 
     let changeId = "";
     if (i % 2 === 0) {
@@ -583,10 +585,6 @@ export function parseLog(output: string): ChangeNode[] {
 
     const match = evenLine.match(/([a-zA-Z0-9(].*)/);
     const description = match ? match[1] : "";
-
-    if (description) {
-      evenLine = evenLine.replace(description, "");
-    }
 
     const emailMatch = oddLine.match(
       /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/,

--- a/src/repoLifecycle.ts
+++ b/src/repoLifecycle.ts
@@ -252,6 +252,110 @@ export const makeRepoLifecycle = (deps: RepoLifecycleDeps): RepoLifecycle => {
     );
   };
 
+  /**
+   * Performs full workspace repository discovery and reconciles open handles.
+   *
+   * This is intentionally used for activation, workspace-folder changes, manual
+   * refreshes, and repository-discovery setting changes. It may probe many
+   * workspace children, so steady-state polling should refresh known repos
+   * instead of calling this on every interval.
+   */
+  const syncReposWithWorkspaceFolders = () =>
+    Effect.gen(function* () {
+      const currentRepoInfos = yield* discoverRepositoriesEffect();
+      const currentRoots = new Set(
+        [...currentRepoInfos.values()].map((info) => info.repoRoot),
+      );
+
+      for (let i = deps.repos.length - 1; i >= 0; i--) {
+        const repo = deps.repos[i];
+        if (!currentRoots.has(repo.config.repositoryRoot)) {
+          logger.info(`Removing repo ${repo.config.repositoryRoot}`);
+          yield* Effect.promise(() => repo.dispose()).pipe(
+            Effect.catchAllCause((cause) => {
+              logger.error(
+                `Failed to dispose repo ${repo.config.repositoryRoot}: ${String(cause)}`,
+              );
+              return Effect.void;
+            }),
+          );
+          deps.repos.splice(i, 1);
+        }
+      }
+
+      for (const [, info] of currentRepoInfos) {
+        if (
+          deps.repos.some(
+            (repo) => repo.config.repositoryRoot === info.repoRoot,
+          )
+        ) {
+          continue;
+        }
+        logger.info(`Discovered new repo ${info.repoRoot}`);
+        yield* Effect.promise(() => initializeRepo(info)).pipe(
+          Effect.catchAllCause((cause) => {
+            logger.error(
+              `Failed to initialize repo ${info.repoRoot}: ${String(cause)}`,
+            );
+            return Effect.void;
+          }),
+        );
+      }
+
+      yield* setContext("jj.reposExist", deps.repos.length > 0).pipe(
+        Effect.catchAll(() => Effect.void),
+      );
+
+      yield* Effect.tryPromise({
+        try: () => deps.reconcileSelectedRepo(),
+        catch: toError,
+      }).pipe(Effect.catchAll(() => Effect.void));
+
+      yield* Effect.sync(() => {
+        deps.decorationProvider.removeStaleRepositories(
+          deps.repos.map((repo) => repo.config.repositoryRoot),
+        );
+      });
+    });
+
+  /**
+   * Refreshes already-open repositories without scanning workspace children.
+   *
+   * Repository refresh has two different costs. Full discovery scans workspace
+   * roots, configured scan paths, and bounded subfolders to find new repos.
+   * Known-repo refresh only updates existing repo state, which is cheap enough
+   * for periodic polling. If no repos are open yet, still run full discovery so
+   * a repo initialized or cloned after activation can appear without reload.
+   */
+  const poll = () =>
+    deps.repos.length === 0
+      ? syncReposWithWorkspaceFolders()
+      : Effect.forEach(
+          deps.repos,
+          (repo) =>
+            Effect.promise(() =>
+              repo.runPromise(
+                checkForUpdates(repo.config).pipe(
+                  Effect.tap((state) => {
+                    if (!state) {
+                      return Effect.void;
+                    }
+                    return Effect.sync(() => applyRepoStateUpdate(repo, state));
+                  }),
+                ),
+              ),
+            ).pipe(
+              Effect.catchAllCause((cause) =>
+                Effect.sync(() => {
+                  logger.error(
+                    `Update error for ${repo.config.repositoryRoot}: ${String(cause)}`,
+                  );
+                }),
+              ),
+            ),
+          { discard: true },
+        );
+
   return {
     initializeDiscoveredRepos: async () => {
       const repoInfos = await deps.runInExtensionScope(
@@ -261,88 +365,7 @@ export const makeRepoLifecycle = (deps: RepoLifecycleDeps): RepoLifecycle => {
         await initializeRepo(info);
       }
     },
-    syncReposWithWorkspaceFolders: () =>
-      Effect.gen(function* () {
-        const currentRepoInfos = yield* discoverRepositoriesEffect();
-        const currentRoots = new Set(
-          [...currentRepoInfos.values()].map((info) => info.repoRoot),
-        );
-
-        for (let i = deps.repos.length - 1; i >= 0; i--) {
-          const repo = deps.repos[i];
-          if (!currentRoots.has(repo.config.repositoryRoot)) {
-            logger.info(`Removing repo ${repo.config.repositoryRoot}`);
-            yield* Effect.promise(() => repo.dispose()).pipe(
-              Effect.catchAllCause((cause) => {
-                logger.error(
-                  `Failed to dispose repo ${repo.config.repositoryRoot}: ${String(cause)}`,
-                );
-                return Effect.void;
-              }),
-            );
-            deps.repos.splice(i, 1);
-          }
-        }
-
-        for (const [, info] of currentRepoInfos) {
-          if (
-            deps.repos.some(
-              (repo) => repo.config.repositoryRoot === info.repoRoot,
-            )
-          ) {
-            continue;
-          }
-          logger.info(`Discovered new repo ${info.repoRoot}`);
-          yield* Effect.promise(() => initializeRepo(info)).pipe(
-            Effect.catchAllCause((cause) => {
-              logger.error(
-                `Failed to initialize repo ${info.repoRoot}: ${String(cause)}`,
-              );
-              return Effect.void;
-            }),
-          );
-        }
-
-        yield* setContext("jj.reposExist", deps.repos.length > 0).pipe(
-          Effect.catchAll(() => Effect.void),
-        );
-
-        yield* Effect.tryPromise({
-          try: () => deps.reconcileSelectedRepo(),
-          catch: toError,
-        }).pipe(Effect.catchAll(() => Effect.void));
-
-        yield* Effect.sync(() => {
-          deps.decorationProvider.removeStaleRepositories(
-            deps.repos.map((repo) => repo.config.repositoryRoot),
-          );
-        });
-      }),
-    poll: () =>
-      Effect.forEach(
-        deps.repos,
-        (repo) =>
-          Effect.promise(() =>
-            repo.runPromise(
-              checkForUpdates(repo.config).pipe(
-                Effect.tap((state) => {
-                  if (!state) {
-                    return Effect.void;
-                  }
-                  return Effect.sync(() => applyRepoStateUpdate(repo, state));
-                }),
-              ),
-            ),
-          ).pipe(
-            Effect.catchAllCause((cause) =>
-              Effect.sync(() => {
-                logger.error(
-                  `Update error for ${repo.config.repositoryRoot}: ${String(cause)}`,
-                );
-              }),
-            ),
-          ),
-        { discard: true },
-      ),
+    syncReposWithWorkspaceFolders,
+    poll,
   };
 };

--- a/src/repoLocator.ts
+++ b/src/repoLocator.ts
@@ -23,11 +23,30 @@ export const makeRepoLocator = (
 ): RepoLocator => ({
   findRepoBySourceControl: (sc) =>
     repos().find((repo) => repo.sourceControl === sc),
-  findRepoByUri: (uri) =>
-    repos().find(
-      (repo) =>
-        !path.relative(repo.config.repositoryRoot, uri.fsPath).startsWith(".."),
-    ),
+  findRepoByUri: (uri) => {
+    // Nested repositories share path prefixes with their parents. The owner of
+    // a file is the most specific open repository, not the first prefix match.
+    let bestMatch: RepoHandle | undefined;
+    for (const repo of repos()) {
+      const relativePath = path.relative(
+        repo.config.repositoryRoot,
+        uri.fsPath,
+      );
+      if (relativePath.startsWith("..")) {
+        continue;
+      }
+
+      if (
+        bestMatch === undefined ||
+        repo.config.repositoryRoot.length >
+          bestMatch.config.repositoryRoot.length
+      ) {
+        bestMatch = repo;
+      }
+    }
+
+    return bestMatch;
+  },
   findRepoByResourceGroup: (rg) =>
     repos().find(
       (repo) => repo.workingCopyGroup === rg || repo.parentGroups.includes(rg),

--- a/src/test/extensionApi.ts
+++ b/src/test/extensionApi.ts
@@ -12,6 +12,15 @@ type ExtensionAPI = {
       input: string,
     ) => { fromPath: string; toPath: string } | null;
     resolveRepoPath: (workspaceRoot: string) => string;
+    traverseWorkspaceFolder: (
+      workspaceFolder: string,
+      maxDepth: number,
+      repositoryScanIgnoredFolders: string[],
+    ) => Promise<string[]>;
+    resolveConfiguredScanFolder: (
+      root: string,
+      scanPath: string,
+    ) => string | undefined;
     fakeEditorPath: string;
     ImmutableError: new (message: string) => Error;
   };

--- a/src/test/resolveRepoPath.test.ts
+++ b/src/test/resolveRepoPath.test.ts
@@ -7,9 +7,19 @@ import { getExtensionAPI } from "./extensionApi";
 suite("resolveRepoPath", () => {
   let tmpDir: string;
   let resolveRepoPath: (workspaceRoot: string) => string;
+  let traverseWorkspaceFolder: (
+    workspaceFolder: string,
+    maxDepth: number,
+    repositoryScanIgnoredFolders: string[],
+  ) => Promise<string[]>;
+  let resolveConfiguredScanFolder: (
+    root: string,
+    scanPath: string,
+  ) => string | undefined;
 
   suiteSetup(async () => {
-    ({ resolveRepoPath } = (await getExtensionAPI()).repository);
+    ({ resolveRepoPath, traverseWorkspaceFolder, resolveConfiguredScanFolder } =
+      (await getExtensionAPI()).repository);
   });
 
   setup(() => {
@@ -64,6 +74,62 @@ suite("resolveRepoPath", () => {
     assert.strictEqual(
       fs.realpathSync(result),
       fs.realpathSync(primaryRepoDir),
+    );
+  });
+
+  test("traverseWorkspaceFolder respects depth and ignored folders", async () => {
+    fs.mkdirSync(path.join(tmpDir, "root", "one", "nested"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(tmpDir, "root", "node_modules", "ignored"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(tmpDir, "root", ".jj", "repo"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(tmpDir, "root", ".git", "ignored"), {
+      recursive: true,
+    });
+
+    const result = await traverseWorkspaceFolder(path.join(tmpDir, "root"), 1, [
+      "node_modules",
+    ]);
+
+    assert.deepStrictEqual(result.sort(), [path.join(tmpDir, "root", "one")]);
+  });
+
+  test("traverseWorkspaceFolder includes unreadable max-depth folders", async () => {
+    const unreadableFolder = path.join(tmpDir, "root", "unreadable");
+    fs.mkdirSync(unreadableFolder, { recursive: true });
+    fs.chmodSync(unreadableFolder, 0o000);
+
+    try {
+      const result = await traverseWorkspaceFolder(
+        path.join(tmpDir, "root"),
+        1,
+        [],
+      );
+
+      assert.deepStrictEqual(result, [unreadableFolder]);
+    } finally {
+      fs.chmodSync(unreadableFolder, 0o700);
+    }
+  });
+
+  test("resolveConfiguredScanFolder rejects paths outside the workspace", () => {
+    const root = path.join(tmpDir, "root");
+
+    assert.strictEqual(
+      resolveConfiguredScanFolder(root, "tools/jjk"),
+      path.join(root, "tools", "jjk"),
+    );
+    assert.strictEqual(
+      resolveConfiguredScanFolder(root, "../other"),
+      undefined,
+    );
+    assert.strictEqual(
+      resolveConfiguredScanFolder(root, "tools/../../other"),
+      undefined,
     );
   });
 });

--- a/src/test/workspaceFolders.test.ts
+++ b/src/test/workspaceFolders.test.ts
@@ -17,6 +17,19 @@ async function createTempJJRepo(prefix: string): Promise<string> {
   return dir;
 }
 
+async function createNestedJJRepos(): Promise<{
+  outerRepoPath: string;
+  innerRepoPath: string;
+}> {
+  const outerRepoPath = await createTempJJRepo("jjk-test-nested-outer-");
+  const innerRepoPath = path.join(outerRepoPath, "inner");
+
+  await fs.mkdir(innerRepoPath, { recursive: true });
+  await execJJPromise("git init", { cwd: innerRepoPath });
+
+  return { outerRepoPath, innerRepoPath };
+}
+
 suite("Dynamic Workspace Folder Tests", () => {
   let workspaceSCM: WorkspaceSourceControlManager;
 
@@ -68,6 +81,55 @@ suite("Dynamic Workspace Folder Tests", () => {
     );
   });
 
+  test("workspace scan discovers nested jj repos", async function () {
+    this.timeout(30_000);
+
+    const initialRepoCount = workspaceSCM.repoSCMs.length;
+    const { outerRepoPath, innerRepoPath } = await createNestedJJRepos();
+
+    const countBefore = (vscode.workspace.workspaceFolders || []).length;
+    const success = vscode.workspace.updateWorkspaceFolders(countBefore, 0, {
+      uri: vscode.Uri.file(outerRepoPath),
+    });
+    if (!success) {
+      // Single-folder mode permits the first single->multi transition but can
+      // reject additional workspace folder updates.
+      this.skip();
+    }
+
+    for (let i = 0; i < 50; i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      if ((vscode.workspace.workspaceFolders || []).length > countBefore) {
+        break;
+      }
+    }
+
+    await vscode.commands.executeCommand("jj.refresh");
+
+    assert.strictEqual(
+      workspaceSCM.repoSCMs.length,
+      initialRepoCount + 2,
+      `Expected ${initialRepoCount + 2} repos after adding nested workspace, ` +
+        `but found ${workspaceSCM.repoSCMs.length}`,
+    );
+
+    assert.ok(
+      workspaceSCM.repoSCMs.some((r) => r.repositoryRoot === outerRepoPath),
+      `Expected to find outer repo with root ${outerRepoPath}`,
+    );
+    assert.ok(
+      workspaceSCM.repoSCMs.some((r) => r.repositoryRoot === innerRepoPath),
+      `Expected to find inner repo with root ${innerRepoPath}`,
+    );
+
+    const innerFile = vscode.Uri.file(path.join(innerRepoPath, "file.txt"));
+    assert.strictEqual(
+      workspaceSCM.getRepositoryFromUri(innerFile)?.repositoryRoot,
+      innerRepoPath,
+      "Expected the deepest nested repo to own files below its root",
+    );
+  });
+
   test("removing a workspace folder removes the repo", async function () {
     this.timeout(30_000);
 
@@ -89,6 +151,13 @@ suite("Dynamic Workspace Folder Tests", () => {
     // Find the folder added by the previous test (the last one)
     const lastIndex = folderCountBefore - 1;
     const folderToRemove = vscode.workspace.workspaceFolders![lastIndex];
+    const reposInRemovedFolder = workspaceSCM.repoSCMs.filter((repo) => {
+      const relativePath = path.relative(
+        folderToRemove.uri.fsPath,
+        repo.repositoryRoot,
+      );
+      return !relativePath.startsWith("..");
+    }).length;
 
     const removeSuccess = vscode.workspace.updateWorkspaceFolders(lastIndex, 1);
     assert.ok(
@@ -109,8 +178,10 @@ suite("Dynamic Workspace Folder Tests", () => {
 
     assert.strictEqual(
       workspaceSCM.repoSCMs.length,
-      repoCountBefore - 1,
-      `Expected ${repoCountBefore - 1} repos after removing workspace folder, ` +
+      repoCountBefore - reposInRemovedFolder,
+      `Expected ${
+        repoCountBefore - reposInRemovedFolder
+      } repos after removing workspace folder, ` +
         `but found ${workspaceSCM.repoSCMs.length}`,
     );
   });

--- a/src/workspaceScmCompat.ts
+++ b/src/workspaceScmCompat.ts
@@ -51,15 +51,14 @@ export function buildWorkspaceSCMCompatLayer(
   repos: () => readonly RepoHandle[],
   fileSystemProvider: JJFileSystemProviderNew,
   repoLocator: RepoLocator,
+  refreshRepos: () => Promise<boolean>,
 ): WorkspaceScmCompatLayer {
   return {
     get repoSCMs() {
       return repos().map((repo) => buildRepoSCMProxy(repo));
     },
     fileSystemProvider,
-    refresh() {
-      return Promise.resolve(false);
-    },
+    refresh: refreshRepos,
     getRepositoryFromUri(uri) {
       const repo = repoLocator.findRepoByUri(uri);
       return repo ? { repositoryRoot: repo.config.repositoryRoot } : undefined;


### PR DESCRIPTION
## Summary

This adds Git-extension-style nested repository discovery for jjk. Opening a container workspace such as `~/code` can now discover sibling jj repos like `~/code/foo` and `~/code/bar` without requiring the user to create a multi-root VS Code workspace by hand.

The implementation intentionally follows the shape of VS Code's built-in Git extension: `autoRepositoryDetection`, `repositoryScanMaxDepth`, `repositoryScanIgnoredFolders`, and `scanRepositories` control a bounded workspace scan. The default scan depth is one level, matching the common `~/code/<repo>` layout while avoiding an unbounded crawl through every descendant directory.

## Implementation notes

Full repository discovery now builds a candidate set from the workspace root, bounded subfolder traversal, and explicit `jjk.scanRepositories` entries. Each candidate is probed with `jj root`, and the returned root is used as the canonical repository identity so duplicate candidates collapse to a single SCM manager.

Background polling uses a cheaper path: it refreshes only known repo roots instead of rescanning every top-level folder on each interval. Full discovery still runs for activation, manual refresh, workspace folder changes, discovery setting changes, and the empty-repo state so a repo initialized after activation can still be picked up.

Nested repository ownership now resolves to the deepest matching repository root, which matches the Git extension's approach for overlapping repo paths. Files inside `outer/inner` are owned by the inner repo instead of the outer repo.

## Edge cases handled

- `jjk.scanRepositories` entries are workspace-relative only; absolute paths and `../` escapes are ignored so shared workspace settings cannot make jjk crawl arbitrary machine-local paths.
- `.jj` and `.git` metadata directories are not treated as candidate workspace roots.
- Max-depth folders are added as candidates before reading their children, so unreadable direct children can still be probed with `jj root` and the default depth avoids unnecessary child `readdir` calls.
- `jj version` is deferred until after `jj root` succeeds, avoiding an extra process spawn for every non-repo scan candidate.
- Removing a workspace folder removes all discovered repos below that folder, not just the workspace root repo.

## Tests

- `npm run compile`
- `npm run compile-tests`
- `npm test`