### PR TITLE
feat: Add hover with commit details and view-changes link to blame annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "jjk",
   "description": "Jujutsu (jj) version control system for VS Code",
   "icon": "images/logo.png",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "engines": {
     "vscode": "^1.96.0",
     "npm": ">=11.10.0"
@@ -198,6 +198,18 @@
         "title": "Open child change",
         "category": "Jujutsu",
         "icon": "$(arrow-right)"
+      },
+      {
+        "command": "jj.viewChange",
+        "title": "View change",
+        "category": "Jujutsu",
+        "icon": "$(compare-changes)"
+      },
+      {
+        "command": "jj.openChangeFileDiff",
+        "title": "Open changes",
+        "category": "Jujutsu",
+        "icon": "$(compare-changes)"
       }
     ],
     "menus": {
@@ -439,6 +451,14 @@
         },
         {
           "command": "jj.openChildChange",
+          "when": "false"
+        },
+        {
+          "command": "jj.viewChange",
+          "when": "false"
+        },
+        {
+          "command": "jj.openChangeFileDiff",
           "when": "false"
         }
       ]

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -4,7 +4,7 @@ import type { JJCli } from "./services/JJCli";
 import type { ExtensionResources } from "./services/ExtensionResources";
 import type { Vscode } from "./services/Vscode";
 import { getActiveTextEditor, getConfigurationValue } from "./services/Vscode";
-import { annotate, getShow } from "./services/Repository";
+import { annotate, getOriginalPath, getShow } from "./services/Repository";
 import type { RepoHandle } from "./repoHandle";
 import { getParams } from "./uri";
 import type { ChangeWithDetails } from "./types";
@@ -122,8 +122,21 @@ export async function setupAnnotations(deps: AnnotationDeps): Promise<void> {
       }
 
       const rev = getAnnotationRev(uri);
+      const params = uri.scheme === "jj" ? getParams(uri) : undefined;
+      const annotateEffect =
+        params && "diffOriginalRev" in params
+          ? getOriginalPath(
+              repo.config,
+              params.diffOriginalRev,
+              uri.fsPath,
+            ).pipe(
+              Effect.flatMap((originalPath) =>
+                annotate(repo.config, originalPath, rev),
+              ),
+            )
+          : annotate(repo.config, uri.fsPath, rev);
       const changeIdsByLine = yield* deps
-        .runRepoEffect(repo, annotate(repo.config, uri.fsPath, rev))
+        .runRepoEffect(repo, annotateEffect)
         .pipe(
           Effect.catchIf(
             (error) => error.message.includes("more than one revision"),
@@ -239,6 +252,73 @@ export async function setupAnnotations(deps: AnnotationDeps): Promise<void> {
       });
     });
 
+  const provideHoverEffect = (
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): Effect.Effect<vscode.Hover | undefined, Error, Vscode> =>
+    Effect.gen(function* () {
+      const state = yield* Ref.get(annotationState);
+      if (
+        !state.annotateInfo ||
+        !uriEquals(state.annotateInfo.uri, document.uri) ||
+        !state.activeLines.includes(position.line)
+      ) {
+        return undefined;
+      }
+
+      // The annotation is rendered after the end of the line, and VS Code
+      // anchors hovers over it at the last character of the line
+      const annotationRange = document.validateRange(
+        new vscode.Range(
+          position.line,
+          2 ** 30 - 1,
+          position.line,
+          2 ** 30 - 1,
+        ),
+      );
+      if (annotationRange.start.character !== position.character) {
+        return undefined;
+      }
+
+      const changeId = state.annotateInfo.changeIdsByLine[position.line];
+      if (!changeId) {
+        return undefined;
+      }
+
+      const repo = deps.findRepoByUri(document.uri);
+      if (!repo) {
+        return undefined;
+      }
+
+      const showResult = yield* deps.runRepoEffect(
+        repo,
+        getShow(repo.config, changeId),
+      );
+      const change = showResult.change;
+      const shortChangeId = change.changeId.substring(0, 8);
+      const viewChangeArgs = encodeURIComponent(
+        JSON.stringify([repo.config.repositoryRoot, change.changeId]),
+      );
+      const openChangesArgs = encodeURIComponent(
+        JSON.stringify([change.changeId, document.uri.fsPath, position.line]),
+      );
+      const message = new vscode.MarkdownString(undefined, true);
+      message.isTrusted = {
+        enabledCommands: ["jj.viewChange", "jj.openChangeFileDiff"],
+      };
+      message.appendMarkdown(
+        `**${change.author.name}** (${change.author.email}) — ${change.authoredDate}\n\n`,
+      );
+      message.appendMarkdown(`${change.description || "(no description)"}\n\n`);
+      message.appendMarkdown("---\n\n");
+      message.appendMarkdown(
+        `[$(git-commit) ${shortChangeId}](command:jj.viewChange?${viewChangeArgs} "View all changes in ${shortChangeId}")` +
+          ` &nbsp;|&nbsp; ` +
+          `[$(compare-changes)](command:jj.openChangeFileDiff?${openChangesArgs} "Open Changes")`,
+      );
+      return new vscode.Hover(message, annotationRange);
+    });
+
   const handleDidChangeActiveTextEditorEffect = (
     editor: vscode.TextEditor | undefined,
   ): Effect.Effect<void, Error, Vscode> =>
@@ -265,6 +345,19 @@ export async function setupAnnotations(deps: AnnotationDeps): Promise<void> {
       yield* setDecorationsEffect(editor, activeLines);
     });
 
+  await deps.registerScoped(() =>
+    vscode.languages.registerHoverProvider(
+      [{ scheme: "file" }, { scheme: "jj" }],
+      {
+        provideHover: (document, position) =>
+          deps.runInExtensionScope(
+            provideHoverEffect(document, position).pipe(
+              Effect.catchAll(() => Effect.succeed(undefined)),
+            ),
+          ),
+      },
+    ),
+  );
   await deps.registerScoped(() =>
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       deps.dispatchExtensionEffect(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,12 @@ export interface InitCommandHandlers {
   readonly squashSelectedRanges: () => unknown;
   readonly openParentChange: (uri: vscode.Uri) => unknown;
   readonly openChildChange: (uri: vscode.Uri) => unknown;
+  readonly viewChange: (repositoryRoot: string, changeId: string) => unknown;
+  readonly openChangeFileDiff: (
+    changeId: string,
+    fsPath: string,
+    line?: number,
+  ) => unknown;
 }
 
 export interface GlobalCommandHandlers {
@@ -190,6 +196,15 @@ export async function registerInitCommands(
     vscode.commands.registerCommand(
       "jj.openChildChange",
       handlers.openChildChange,
+    ),
+  );
+  await registerScoped(() =>
+    vscode.commands.registerCommand("jj.viewChange", handlers.viewChange),
+  );
+  await registerScoped(() =>
+    vscode.commands.registerCommand(
+      "jj.openChangeFileDiff",
+      handlers.openChangeFileDiff,
     ),
   );
 }

--- a/src/fileSystemProviderNew.ts
+++ b/src/fileSystemProviderNew.ts
@@ -142,17 +142,30 @@ export class JJFileSystemProviderNew implements FileSystemProvider {
     const rev =
       "diffOriginalRev" in params ? params.diffOriginalRev : params.rev;
 
+    // The original side of a diff for `rev` is the file's content before `rev`,
+    // i.e. at the parent. A file absent there (added or renamed in `rev`) has an
+    // empty original, matching a plain "file added" diff.
+    const readOriginalAtParent = readFileEffect(
+      repo.config,
+      `${rev}-`,
+      uri.fsPath,
+    ).pipe(
+      Effect.catchAll((e) =>
+        e instanceof Error && e.message.includes("No such path")
+          ? Effect.succeed(new Uint8Array())
+          : Effect.fail(e),
+      ),
+    );
+
     const effect =
       "diffOriginalRev" in params
         ? // Try getDiffOriginal first (fakeeditor-based, handles renames correctly),
-          // then fall back to readFile
+          // then fall back to reading the parent revision directly.
           getDiffOriginal(repo.config, rev, uri.fsPath).pipe(
             Effect.flatMap((data) =>
-              data
-                ? Effect.succeed(data)
-                : readFileEffect(repo.config, rev, uri.fsPath),
+              data ? Effect.succeed(data) : readOriginalAtParent,
             ),
-            Effect.catchAll(() => readFileEffect(repo.config, rev, uri.fsPath)),
+            Effect.catchAll(() => readOriginalAtParent),
           )
         : readFileEffect(repo.config, rev, uri.fsPath);
 

--- a/src/navigationCommandHandlers.ts
+++ b/src/navigationCommandHandlers.ts
@@ -133,6 +133,8 @@ export const createNavigationInitHandlers = (
   | "gitFetch"
   | "openParentChange"
   | "openChildChange"
+  | "viewChange"
+  | "openChangeFileDiff"
 > => ({
   openFileResourceState: (resourceState) =>
     deps.runExtensionEffect(
@@ -335,6 +337,56 @@ export const createNavigationInitHandlers = (
     deps.dispatchExtensionEffect(
       openRelatedChangeEffect(deps, uri, "+", "Child"),
       "Failed to open child change",
+    );
+  },
+  viewChange: (repositoryRoot, changeId) => {
+    const repo = deps.repoLocator.findRepoByUri(
+      vscode.Uri.file(repositoryRoot),
+    );
+    if (!repo) {
+      return;
+    }
+
+    return deps.runRepoCommand(
+      repo,
+      Effect.gen(function* () {
+        const showResult = yield* getShow(repo.config, changeId);
+        const resources = showResult.fileStatuses.map((fileStatus) => {
+          const fileUri = vscode.Uri.file(fileStatus.path);
+          return [
+            fileUri,
+            fileStatus.type === "A"
+              ? undefined
+              : toJJUri(fileUri, { diffOriginalRev: changeId }),
+            fileStatus.type === "D"
+              ? undefined
+              : toJJUri(fileUri, { rev: changeId }),
+          ];
+        });
+        yield* executeCommand(
+          "vscode.changes",
+          `Changes in ${changeId.substring(0, 8)}`,
+          resources,
+        );
+      }),
+      "Failed to view change",
+    );
+  },
+  openChangeFileDiff: (changeId, fsPath, line) => {
+    const fileUri = vscode.Uri.file(fsPath);
+    const options: vscode.TextDocumentShowOptions | undefined =
+      line !== undefined
+        ? { selection: new vscode.Range(line, 0, line, 0) }
+        : undefined;
+    return deps.runExtensionEffect(
+      executeCommand(
+        "vscode.diff",
+        toJJUri(fileUri, { diffOriginalRev: changeId }),
+        toJJUri(fileUri, { rev: changeId }),
+        `${path.basename(fsPath)} (${changeId.substring(0, 8)})`,
+        options,
+      ),
+      "Failed to open changes",
     );
   },
 });

--- a/src/services/Repository.ts
+++ b/src/services/Repository.ts
@@ -330,6 +330,39 @@ export const annotate = (
     return lines.map((line) => line.split(" ")[0]);
   });
 
+// Resolves the path a file had before `rev`. If `rev` renamed the file, the
+// path at its parent is the rename source; otherwise it is unchanged.
+export const getOriginalPath = (
+  config: RepositoryConfig,
+  rev: string,
+  filepath: string,
+): Effect.Effect<string, JJCliError | JJImmutableError, RepositoryEnv> =>
+  Effect.gen(function* () {
+    const cli = yield* JJCli;
+    const output = yield* cli.run(["diff", "--summary", "-r", rev], {
+      timeout: 10_000,
+      ignoreWorkingCopy: true,
+    });
+    const normalizedTarget = path.normalize(filepath).replace(/\\/g, "/");
+    for (const raw of output.trim().split("\n")) {
+      const line = raw.trim();
+      if (line.charAt(0) !== "R" && line.charAt(0) !== "C") {
+        continue;
+      }
+      const parsed = parseRenamePaths(line.slice(2).trim());
+      if (!parsed) {
+        continue;
+      }
+      const toPath = path
+        .join(config.repositoryRoot, parsed.toPath)
+        .replace(/\\/g, "/");
+      if (pathEquals(toPath, normalizedTarget)) {
+        return path.join(config.repositoryRoot, parsed.fromPath);
+      }
+    }
+    return filepath;
+  });
+
 export const log = (
   _config: RepositoryConfig,
   rev: string = "::",

--- a/src/test/fileSystemProvider.test.ts
+++ b/src/test/fileSystemProvider.test.ts
@@ -45,6 +45,113 @@ suite("JJFileSystemProvider", () => {
     await vscode.commands.executeCommand("jj.refresh");
   });
 
+  async function readJJText(
+    filePath: string,
+    params: Parameters<typeof UriModule.toJJUri>[1],
+  ): Promise<string> {
+    const uri = toJJUri(vscode.Uri.file(filePath), params);
+    const bytes = await vscode.workspace.fs.readFile(uri);
+    return Buffer.from(bytes).toString();
+  }
+
+  // Builds a chain @-- (adds file=v1) -> @- (modifies file to v2) -> @, and
+  // returns the change ids of the two ancestor commits.
+  async function buildChangeChain(
+    fileName: string,
+    v1: string,
+    v2: string,
+  ): Promise<{ filePath: string; changeAdd: string; changeModify: string }> {
+    const filePath = path.join(repoRoot, fileName);
+    const opts = { cwd: repoRoot };
+
+    await execJJPromise('new -m "fsp-add"', opts);
+    await fs.writeFile(filePath, v1);
+    await execJJPromise('new -m "fsp-modify"', opts);
+    await fs.writeFile(filePath, v2);
+    await execJJPromise('new -m "fsp-tip"', opts);
+
+    const changeAdd = (
+      await execJJPromise('log -r @-- --no-graph -T "change_id"', opts)
+    ).stdout.trim();
+    const changeModify = (
+      await execJJPromise('log -r @- --no-graph -T "change_id"', opts)
+    ).stdout.trim();
+    return { filePath, changeAdd, changeModify };
+  }
+
+  test("diffOriginalRev reads the file content from before the change", async function () {
+    this.timeout(30_000);
+
+    const { filePath, changeModify } = await buildChangeChain(
+      "test-fsp-difforig.txt",
+      "v1\n",
+      "v2\n",
+    );
+
+    assert.strictEqual(
+      await readJJText(filePath, { diffOriginalRev: changeModify }),
+      "v1\n",
+      "Original side should be the content before the change",
+    );
+    assert.strictEqual(
+      await readJJText(filePath, { rev: changeModify }),
+      "v2\n",
+      "Modified side should be the content at the change",
+    );
+  });
+
+  test("diffOriginalRev is empty when the file did not exist before the change", async function () {
+    this.timeout(30_000);
+
+    const { filePath, changeAdd } = await buildChangeChain(
+      "test-fsp-added.txt",
+      "v1\n",
+      "v2\n",
+    );
+
+    assert.strictEqual(
+      await readJJText(filePath, { diffOriginalRev: changeAdd }),
+      "",
+      "A file added by the change has no original content",
+    );
+  });
+
+  test("openChangeFileDiff reveals the requested line", async function () {
+    this.timeout(30_000);
+
+    const { filePath, changeModify } = await buildChangeChain(
+      "test-fsp-scroll.txt",
+      "a\nb\nc\nd\ne\nf\n",
+      "a\nb\nC\nd\ne\nf\n",
+    );
+
+    const targetLine = 3;
+    await vscode.commands.executeCommand(
+      "jj.openChangeFileDiff",
+      changeModify,
+      filePath,
+      targetLine,
+    );
+
+    let editor: vscode.TextEditor | undefined;
+    for (let i = 0; i < 20; i++) {
+      editor = vscode.window.activeTextEditor;
+      if (editor && editor.selection.active.line === targetLine) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    assert.ok(editor, "Expected an active diff editor");
+    assert.strictEqual(
+      editor.selection.active.line,
+      targetLine,
+      "Diff should be scrolled to the requested line",
+    );
+
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+  });
+
   test("cleanup retains cache entries for open jj:// documents", async function () {
     this.timeout(30_000);
 


### PR DESCRIPTION
This change introduces a popover which appears when a user hovers over the blame annotation. This popover shows the extended change description, with a link to open the change, and a link to view the change at the specific line being hovered.

This allows users to easily follow how a specific line has changed over time.

Examples:
For this changelog:
<img width="579" height="118" alt="image" src="https://github.com/user-attachments/assets/acccffed-7370-47ff-a253-03fba93d4339" />

A totally new file
<img width="716" height="203" alt="image" src="https://github.com/user-attachments/assets/e6229bf4-44e5-45b3-aef9-7068f2dbdc70" />
Clicking the "Open changes" icon shows the entire file changed
<img width="1544" height="301" alt="image" src="https://github.com/user-attachments/assets/6649b66a-c80f-4ba1-8b8d-0181dcba8e9b" />

A changed line on the file:
<img width="719" height="184" alt="image" src="https://github.com/user-attachments/assets/d00435bc-1b78-4558-9544-d9a12da29027" />

Clicking the "Open changes" icon on the change:
<img width="1346" height="199" alt="image" src="https://github.com/user-attachments/assets/31b0eda0-d133-4b97-94b2-4814f885570f" />

Within the change editor, viewing the change for a "previous" revision:
<img width="1314" height="258" alt="image" src="https://github.com/user-attachments/assets/158595b4-d998-4e8c-b11b-56255e59043b" />

Adding a new change:
<img width="709" height="152" alt="image" src="https://github.com/user-attachments/assets/fbbedbff-48b7-485d-a271-84f1982e6a59" />

Can still see the change from the previous changes:
<img width="602" height="203" alt="image" src="https://github.com/user-attachments/assets/76c53bdd-ab11-46b3-ba62-4b211295c4e0" />

